### PR TITLE
[FEAT] 게시글 목록 조회 (구버전)

### DIFF
--- a/src/main/java/org/aibe4/dodeul/domain/board/controller/BoardPostApiController.java
+++ b/src/main/java/org/aibe4/dodeul/domain/board/controller/BoardPostApiController.java
@@ -1,0 +1,96 @@
+// src/main/java/org/aibe4/dodeul/domain/board/controller/BoardPostApiController.java
+package org.aibe4.dodeul.domain.board.controller;
+
+import java.util.List;
+import org.aibe4.dodeul.domain.board.model.dto.BoardPostListPageResponse;
+import org.aibe4.dodeul.domain.board.model.dto.BoardPostListRequest;
+import org.aibe4.dodeul.domain.board.model.dto.BoardPostListResponse;
+import org.aibe4.dodeul.domain.board.service.BoardPostService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/board/posts")
+public class BoardPostApiController {
+
+    private final BoardPostService boardPostService;
+
+    public BoardPostApiController(BoardPostService boardPostService) {
+        this.boardPostService = boardPostService;
+    }
+
+    /**
+     * 게시글 목록 조회
+     *
+     * <p>임시 규칙: Authorization 헤더가 "Bearer {memberId}" 형태면 memberId로 간주한다.
+     */
+    @GetMapping
+    public ResponseEntity<BoardPostListPageResponse> listPosts(
+            @RequestHeader(value = "Authorization", required = false) String authorization,
+            @RequestParam(value = "consultingTagId", required = false) Long consultingTagId,
+            @RequestParam(value = "tagIds", required = false) List<Long> tagIds,
+            @RequestParam(value = "status", required = false) String status,
+            @RequestParam(value = "sort", required = false, defaultValue = "LATEST") String sort,
+            @RequestParam(value = "keyword", required = false) String keyword,
+            @RequestParam(value = "page", required = false, defaultValue = "0") Integer page,
+            @RequestParam(value = "size", required = false, defaultValue = "20") Integer size) {
+
+        Long memberId = parseMemberIdFromAuthorization(authorization);
+
+        BoardPostListRequest request =
+                BoardPostListRequest.builder()
+                        .consultingTagId(consultingTagId)
+                        .skillTagIds(tagIds)
+                        .status(status)
+                        .sort(sort)
+                        .keyword(keyword)
+                        .page(page)
+                        .size(size)
+                        .build();
+
+        Pageable pageable = PageRequest.of(page, size, toSpringSort(sort));
+
+        Page<BoardPostListResponse> result = boardPostService.getPosts(request, memberId, pageable);
+
+        return ResponseEntity.ok(BoardPostListPageResponse.from(result));
+    }
+
+    private Sort toSpringSort(String sort) {
+        if (sort == null || sort.isBlank() || "LATEST".equalsIgnoreCase(sort)) {
+            return Sort.by(Sort.Direction.DESC, "createdAt");
+        }
+
+        if ("VIEWS".equalsIgnoreCase(sort)) {
+            return Sort.by(Sort.Direction.DESC, "viewCount")
+                    .and(Sort.by(Sort.Direction.DESC, "createdAt"));
+        }
+
+        if ("ACTIVE".equalsIgnoreCase(sort)) {
+            return Sort.by(Sort.Direction.DESC, "lastCommentedAt")
+                    .and(Sort.by(Sort.Direction.DESC, "createdAt"));
+        }
+
+        return Sort.by(Sort.Direction.DESC, "createdAt");
+    }
+
+    private Long parseMemberIdFromAuthorization(String authorization) {
+        if (authorization == null || !authorization.startsWith("Bearer ")) {
+            return null;
+        }
+
+        String token = authorization.substring("Bearer ".length()).trim();
+        try {
+            return Long.parseLong(token);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/org/aibe4/dodeul/domain/board/model/dto/BoardPostListPageResponse.java
+++ b/src/main/java/org/aibe4/dodeul/domain/board/model/dto/BoardPostListPageResponse.java
@@ -1,0 +1,32 @@
+// src/main/java/org/aibe4/dodeul/domain/board/model/dto/BoardPostListPageResponse.java
+package org.aibe4.dodeul.domain.board.model.dto;
+
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class BoardPostListPageResponse {
+
+    private final List<BoardPostListResponse> content;
+    private final int page;
+    private final int size;
+    private final long totalElements;
+    private final int totalPages;
+    private final boolean first;
+    private final boolean last;
+
+    public static BoardPostListPageResponse from(Page<BoardPostListResponse> pageResult) {
+        return new BoardPostListPageResponse(
+                pageResult.getContent(),
+                pageResult.getNumber(),
+                pageResult.getSize(),
+                pageResult.getTotalElements(),
+                pageResult.getTotalPages(),
+                pageResult.isFirst(),
+                pageResult.isLast());
+    }
+}

--- a/src/main/java/org/aibe4/dodeul/domain/board/model/dto/BoardPostListRequest.java
+++ b/src/main/java/org/aibe4/dodeul/domain/board/model/dto/BoardPostListRequest.java
@@ -1,0 +1,27 @@
+package org.aibe4.dodeul.domain.board.model.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BoardPostListRequest {
+
+    private Long consultingTagId;
+    private List<Long> skillTagIds;
+
+    // 없거나 잘못되면 OPEN
+    private String status;
+    private String keyword;
+
+    // LATEST / VIEWS / ACTIVE
+    private String sort;
+
+    private Integer page;
+    private Integer size;
+}

--- a/src/main/java/org/aibe4/dodeul/domain/board/model/dto/BoardPostListResponse.java
+++ b/src/main/java/org/aibe4/dodeul/domain/board/model/dto/BoardPostListResponse.java
@@ -1,0 +1,29 @@
+// src/main/java/org/aibe4/dodeul/domain/board/model/dto/BoardPostListResponse.java
+package org.aibe4.dodeul.domain.board.model.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/** 게시글 목록 아이템 DTO */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BoardPostListResponse {
+
+    private Long postId;
+    private ConsultingTagDto consultingTag;
+    private String title;
+    private String postStatus;
+    private long viewCount;
+    private long scrapCount;
+    private long commentCount;
+    private LocalDateTime lastCommentedAt;
+    private LocalDateTime createdAt;
+    private boolean scrappedByMe;
+    private List<String> skillTags;
+}

--- a/src/main/java/org/aibe4/dodeul/domain/board/model/dto/ConsultingTagDto.java
+++ b/src/main/java/org/aibe4/dodeul/domain/board/model/dto/ConsultingTagDto.java
@@ -1,0 +1,17 @@
+// src/main/java/org/aibe4/dodeul/domain/board/model/dto/ConsultingTagDto.java
+package org.aibe4.dodeul.domain.board.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/** 상담분야 DTO (현재는 이름만 사용) */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ConsultingTagDto {
+
+    private String name;
+}

--- a/src/main/java/org/aibe4/dodeul/domain/board/model/entity/BoardPostTagRelation.java
+++ b/src/main/java/org/aibe4/dodeul/domain/board/model/entity/BoardPostTagRelation.java
@@ -1,13 +1,9 @@
 package org.aibe4.dodeul.domain.board.model.entity;
 
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.aibe4.dodeul.domain.common.model.entity.BaseEntity;
-
-// import org.aibe4.dodeul.domain.tag.model.entity.SkillTag;
+import org.aibe4.dodeul.domain.common.model.entity.SkillTag;
 
 @Entity
 @Table(
@@ -21,17 +17,13 @@ public class BoardPostTagRelation extends BaseEntity {
     @JoinColumn(name = "board_post_id", nullable = false)
     private BoardPost boardPost;
 
-    // TODO: SkillTag Entity 완성 후 @ManyToOne 관계로 변경
-    // @ManyToOne(fetch = FetchType.LAZY)
-    // @JoinColumn(name = "skill_tag_id", nullable = false)
-    // private SkillTag skillTag;
-
-    @Column(name = "skill_tag_id", nullable = false)
-    private Long skillTagId; // 임시 사용
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "skill_tag_id", nullable = false)
+    private SkillTag skillTag;
 
     @Builder
-    public BoardPostTagRelation(BoardPost boardPost, Long skillTagId) {
+    public BoardPostTagRelation(BoardPost boardPost, SkillTag skillTag) {
         this.boardPost = boardPost;
-        this.skillTagId = skillTagId;
+        this.skillTag = skillTag;
     }
 }

--- a/src/main/java/org/aibe4/dodeul/domain/board/repository/BoardPostRepository.java
+++ b/src/main/java/org/aibe4/dodeul/domain/board/repository/BoardPostRepository.java
@@ -1,0 +1,9 @@
+package org.aibe4.dodeul.domain.board.repository;
+
+import org.aibe4.dodeul.domain.board.model.entity.BoardPost;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BoardPostRepository
+        extends JpaRepository<BoardPost, Long>, BoardPostRepositoryCustom {}

--- a/src/main/java/org/aibe4/dodeul/domain/board/repository/BoardPostRepositoryCustom.java
+++ b/src/main/java/org/aibe4/dodeul/domain/board/repository/BoardPostRepositoryCustom.java
@@ -1,0 +1,11 @@
+package org.aibe4.dodeul.domain.board.repository;
+
+import org.aibe4.dodeul.domain.board.model.dto.BoardPostListRequest;
+import org.aibe4.dodeul.domain.board.model.dto.BoardPostListResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface BoardPostRepositoryCustom {
+    Page<BoardPostListResponse> findPosts(
+            BoardPostListRequest request, Long memberId, Pageable pageable);
+}

--- a/src/main/java/org/aibe4/dodeul/domain/board/repository/BoardPostRepositoryImpl.java
+++ b/src/main/java/org/aibe4/dodeul/domain/board/repository/BoardPostRepositoryImpl.java
@@ -1,0 +1,207 @@
+// src/main/java/org/aibe4/dodeul/domain/board/repository/BoardPostRepositoryImpl.java
+package org.aibe4.dodeul.domain.board.repository;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.TypedQuery;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Order;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import jakarta.persistence.criteria.Subquery;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.aibe4.dodeul.domain.board.model.dto.BoardPostListRequest;
+import org.aibe4.dodeul.domain.board.model.dto.BoardPostListResponse;
+import org.aibe4.dodeul.domain.board.model.dto.ConsultingTagDto;
+import org.aibe4.dodeul.domain.board.model.entity.BoardPost;
+import org.aibe4.dodeul.domain.board.model.entity.BoardPostTagRelation;
+import org.aibe4.dodeul.domain.board.model.entity.PostStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+@Transactional(readOnly = true)
+public class BoardPostRepositoryImpl implements BoardPostRepositoryCustom {
+
+    private final EntityManager em;
+
+    public BoardPostRepositoryImpl(EntityManager em) {
+        this.em = em;
+    }
+
+    @Override
+    public Page<BoardPostListResponse> findPosts(
+            BoardPostListRequest request, Long memberId, Pageable pageable) {
+
+        CriteriaBuilder cb = em.getCriteriaBuilder();
+
+        // --- count query ---
+        CriteriaQuery<Long> countQuery = cb.createQuery(Long.class);
+        Root<BoardPost> countRoot = countQuery.from(BoardPost.class);
+
+        List<Predicate> countPredicates = buildPredicates(cb, countQuery, countRoot, request);
+        countQuery.select(cb.countDistinct(countRoot));
+        if (!countPredicates.isEmpty()) {
+            countQuery.where(cb.and(countPredicates.toArray(new Predicate[0])));
+        }
+
+        Long total = em.createQuery(countQuery).getSingleResult();
+        if (total == 0) {
+            return new PageImpl<>(Collections.emptyList(), pageable, 0);
+        }
+
+        // --- data query ---
+        CriteriaQuery<BoardPost> dataQuery = cb.createQuery(BoardPost.class).distinct(true);
+        Root<BoardPost> root = dataQuery.from(BoardPost.class);
+
+        List<Predicate> predicates = buildPredicates(cb, dataQuery, root, request);
+        if (!predicates.isEmpty()) {
+            dataQuery.where(cb.and(predicates.toArray(new Predicate[0])));
+        }
+
+        if (pageable.getSort().isSorted()) {
+            List<Order> orders = new ArrayList<>();
+            for (Sort.Order o : pageable.getSort()) {
+                if (o.isAscending()) {
+                    orders.add(cb.asc(root.get(o.getProperty())));
+                } else {
+                    orders.add(cb.desc(root.get(o.getProperty())));
+                }
+            }
+            dataQuery.orderBy(orders);
+        } else {
+            dataQuery.orderBy(cb.desc(root.get("createdAt")));
+        }
+
+        TypedQuery<BoardPost> typedQuery = em.createQuery(dataQuery);
+        typedQuery.setFirstResult((int) pageable.getOffset());
+        typedQuery.setMaxResults(pageable.getPageSize());
+
+        List<BoardPost> posts = typedQuery.getResultList();
+        List<Long> postIds = posts.stream().map(BoardPost::getId).collect(Collectors.toList());
+
+        final Set<Long> scrappedPostIds;
+        if (memberId != null && !postIds.isEmpty()) {
+            TypedQuery<Long> q =
+                    em.createQuery(
+                            "select s.boardPost.id "
+                                    + "from BoardPostScrap s "
+                                    + "where s.memberId = :memberId "
+                                    + "and s.boardPost.id in :postIds",
+                            Long.class);
+            q.setParameter("memberId", memberId);
+            q.setParameter("postIds", postIds);
+            scrappedPostIds = new HashSet<>(q.getResultList());
+        } else {
+            scrappedPostIds = Collections.emptySet();
+        }
+
+        Map<Long, List<String>> tagMap = new HashMap<>();
+        if (!postIds.isEmpty()) {
+            TypedQuery<Object[]> relQ =
+                    em.createQuery(
+                            "select r.boardPost.id, r.skillTag.name "
+                                    + "from BoardPostTagRelation r "
+                                    + "where r.boardPost.id in :postIds",
+                            Object[].class);
+            relQ.setParameter("postIds", postIds);
+
+            for (Object[] row : relQ.getResultList()) {
+                Long postId = ((Number) row[0]).longValue();
+                String tagName = (String) row[1];
+                if (tagName == null) {
+                    continue;
+                }
+                tagMap.computeIfAbsent(postId, k -> new ArrayList<>()).add(tagName);
+            }
+        }
+
+        List<BoardPostListResponse> dtos =
+                posts.stream()
+                        .map(
+                                (BoardPost p) ->
+                                        BoardPostListResponse.builder()
+                                                .postId(p.getId())
+                                                .consultingTag(
+                                                        ConsultingTagDto.builder()
+                                                                .name(p.getBoardConsulting())
+                                                                .build())
+                                                .title(p.getTitle())
+                                                .postStatus(
+                                                        p.getPostStatus() != null
+                                                                ? p.getPostStatus().name()
+                                                                : null)
+                                                .viewCount(
+                                                        p.getViewCount() != null
+                                                                ? p.getViewCount()
+                                                                : 0)
+                                                .scrapCount(
+                                                        p.getScrapCount() != null
+                                                                ? p.getScrapCount()
+                                                                : 0)
+                                                .commentCount(
+                                                        p.getCommentCount() != null
+                                                                ? p.getCommentCount()
+                                                                : 0)
+                                                .lastCommentedAt(p.getLastCommentedAt())
+                                                .createdAt(p.getCreatedAt())
+                                                .scrappedByMe(scrappedPostIds.contains(p.getId()))
+                                                .skillTags(
+                                                        tagMap.getOrDefault(
+                                                                p.getId(), Collections.emptyList()))
+                                                .build())
+                        .collect(Collectors.toList());
+
+        return new PageImpl<>(dtos, pageable, total);
+    }
+
+    private List<Predicate> buildPredicates(
+            CriteriaBuilder cb,
+            CriteriaQuery<?> query,
+            Root<BoardPost> root,
+            BoardPostListRequest request) {
+
+        List<Predicate> predicates = new ArrayList<>();
+
+        PostStatus status = PostStatus.OPEN;
+        if (request.getStatus() != null && !request.getStatus().isBlank()) {
+            try {
+                status = PostStatus.valueOf(request.getStatus());
+            } catch (IllegalArgumentException e) {
+                // 잘못된 상태 값이 들어온 경우 기본 OPEN 유지
+            }
+        }
+        predicates.add(cb.equal(root.get("postStatus"), status));
+
+        if (request.getKeyword() != null && !request.getKeyword().isBlank()) {
+            String kw = "%" + request.getKeyword().trim() + "%";
+            predicates.add(cb.or(cb.like(root.get("title"), kw), cb.like(root.get("content"), kw)));
+        }
+
+        if (request.getSkillTagIds() != null && !request.getSkillTagIds().isEmpty()) {
+            Subquery<Integer> sub = query.subquery(Integer.class);
+            Root<BoardPostTagRelation> rel = sub.from(BoardPostTagRelation.class);
+
+            Predicate p1 = cb.equal(rel.get("boardPost").get("id"), root.get("id"));
+            Predicate p2 = rel.get("skillTag").get("id").in(request.getSkillTagIds());
+
+            sub.select(cb.literal(1));
+            sub.where(cb.and(p1, p2));
+
+            predicates.add(cb.exists(sub));
+        }
+
+        return predicates;
+    }
+}

--- a/src/main/java/org/aibe4/dodeul/domain/board/service/BoardPostService.java
+++ b/src/main/java/org/aibe4/dodeul/domain/board/service/BoardPostService.java
@@ -1,0 +1,24 @@
+// src/main/java/org/aibe4/dodeul/domain/board/service/BoardPostService.java
+package org.aibe4.dodeul.domain.board.service;
+
+import lombok.RequiredArgsConstructor;
+import org.aibe4.dodeul.domain.board.model.dto.BoardPostListRequest;
+import org.aibe4.dodeul.domain.board.model.dto.BoardPostListResponse;
+import org.aibe4.dodeul.domain.board.repository.BoardPostRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BoardPostService {
+
+    private final BoardPostRepository boardPostRepository;
+
+    public Page<BoardPostListResponse> getPosts(
+            BoardPostListRequest request, Long memberId, Pageable pageable) {
+        return boardPostRepository.findPosts(request, memberId, pageable);
+    }
+}

--- a/src/main/java/org/aibe4/dodeul/global/security/SecurityConfig.java
+++ b/src/main/java/org/aibe4/dodeul/global/security/SecurityConfig.java
@@ -1,5 +1,6 @@
 package org.aibe4.dodeul.global.security;
 
+import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
@@ -8,8 +9,6 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.cors.*;
-
-import java.util.List;
 
 @Configuration
 public class SecurityConfig {
@@ -26,51 +25,56 @@ public class SecurityConfig {
                 .cors(Customizer.withDefaults())
 
                 // CSRF: UI는 보호, API는 제외(개발 편의)
-                .csrf(csrf -> csrf
-                        .ignoringRequestMatchers("/api/**")
-                )
+                .csrf(csrf -> csrf.ignoringRequestMatchers("/api/**"))
 
                 // URL 권한
-                .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(
-                                "/", "/error",
-                                "/css/**", "/js/**", "/images/**", "/favicon.ico",
-                                "/auth/**",
-                                "/api/auth/**",
-
-                                "/swagger-ui.html",
-                                "/swagger-ui/**",
-                                "/v3/api-docs/**",
-
-                                "/oauth2/**",
-                                "/login/oauth2/**",
-                                "/login",
-                                "/h2-console/**"
-                        ).permitAll()
-                        .requestMatchers("/mypage/**", "/api/**").authenticated()
-                        .anyRequest().authenticated()
-                )
+                .authorizeHttpRequests(
+                        auth ->
+                                auth.requestMatchers(
+                                                "/",
+                                                "/error",
+                                                "/css/**",
+                                                "/js/**",
+                                                "/images/**",
+                                                "/favicon.ico",
+                                                "/auth/**",
+                                                "/api/auth/**",
+                                                "/swagger-ui.html",
+                                                "/swagger-ui/**",
+                                                "/v3/api-docs/**",
+                                                "/oauth2/**",
+                                                "/login/oauth2/**",
+                                                "/login",
+                                                "/h2-console/**",
+                                                "/board/posts",
+                                                "/board/posts/")
+                                        .permitAll()
+                                        .requestMatchers("/mypage/**", "/api/**")
+                                        .authenticated()
+                                        .anyRequest()
+                                        .authenticated())
 
                 // 세션 관리
-                .sessionManagement(session -> session
-                        .sessionFixation(sessionFixation -> sessionFixation.migrateSession())
-                        .invalidSessionUrl("/auth/login?expired")
-                )
+                .sessionManagement(
+                        session ->
+                                session.sessionFixation(
+                                                sessionFixation -> sessionFixation.migrateSession())
+                                        .invalidSessionUrl("/auth/login?expired"))
 
                 // 로그인/로그아웃
-                .formLogin(form -> form
-                        .loginPage("/auth/login")
-                        .loginProcessingUrl("/login")
-                        .defaultSuccessUrl("/mypage/dashboard", true)
-                        .permitAll()
-                )
-                .logout(logout -> logout
-                        .logoutUrl("/logout")
-                        .invalidateHttpSession(true)
-                        .deleteCookies("JSESSIONID")
-                        .logoutSuccessUrl("/auth/login")
-                );
-        //H2 console iframe 차단 방지
+                .formLogin(
+                        form ->
+                                form.loginPage("/auth/login")
+                                        .loginProcessingUrl("/login")
+                                        .defaultSuccessUrl("/mypage/dashboard", true)
+                                        .permitAll())
+                .logout(
+                        logout ->
+                                logout.logoutUrl("/logout")
+                                        .invalidateHttpSession(true)
+                                        .deleteCookies("JSESSIONID")
+                                        .logoutSuccessUrl("/auth/login"));
+        // H2 console iframe 차단 방지
         http.headers(headers -> headers.frameOptions(frame -> frame.sameOrigin()));
 
         return http.build();
@@ -90,4 +94,3 @@ public class SecurityConfig {
         return source;
     }
 }
-


### PR DESCRIPTION
## 기능 개요

* 게시글 목록 조회 API를 추가했습니다.
* 비로그인 사용자는 목록 조회만 가능하며, 상세/기타 게시판 관련 API는 인증을 요구합니다.

## 구현 내용

* `GET /board/posts` 게시글 목록 조회 API 추가
* 목록 조회 요청/응답 DTO 및 페이지 응답 DTO 구성
* 정렬(`LATEST / VIEWS / ACTIVE`), 페이징, 필터링 파라미터 처리
* Repository Custom 구현으로 목록 조회 쿼리 분리
* Security 설정에 게시글 목록 공개 접근 경로 반영

## 접근 정책

* 목록 조회(`/board/posts`): 비로그인 허용
* 그 외 게시판 관련 API: 인증 필요

## 테스트

* 로컬 환경에서 API 정상 동작 확인
* 테스트 코드는 PR 범위에서 제외했습니다.

## 연관 이슈

#11

## 체크리스트

* [x] PR 제목 규칙을 준수했습니다
* [x] 관련 이슈를 연결했습니다
* [x] 구현 범위를 명확히 작성했습니다
* [x] 로컬 환경에서 정상 동작을 확인했습니다

## 리뷰어에게

* 게시글 목록 API의 URL 구조(`/board/posts`) 및 접근 정책 위주로 확인 부탁드립니다.
