### PR TITLE
[FEAT] custom user details 기반 보안 인증 객체 구현

### DIFF
--- a/src/main/java/org/aibe4/dodeul/global/security/CustomUserDetails.java
+++ b/src/main/java/org/aibe4/dodeul/global/security/CustomUserDetails.java
@@ -1,8 +1,8 @@
 package org.aibe4.dodeul.global.security;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.aibe4.dodeul.domain.member.model.enums.Role;
+import org.springframework.security.core.CredentialsContainer;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -11,28 +11,40 @@ import java.util.Collection;
 import java.util.List;
 
 @Getter
-@RequiredArgsConstructor
-public class CustomUserDetails implements UserDetails {
+public class CustomUserDetails implements UserDetails, CredentialsContainer {
 
     private final Long memberId;
     private final String email;
-    private final String passwordHash;
+    private String passwordHash;
     private final Role role;
+    private final Collection<? extends GrantedAuthority> authorities;
+
+    public CustomUserDetails(Long memberId, String email, String passwordHash, Role role) {
+        this.memberId = memberId;
+        this.email = email;
+        this.passwordHash = passwordHash;
+        this.role = role;
+        this.authorities = List.of(new SimpleGrantedAuthority("ROLE_" + role.name()));
+    }
+
+    @Override
+    public void eraseCredentials() {
+        this.passwordHash = null;
+    }
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return List.of(new SimpleGrantedAuthority("ROLE_" + role.name()));
+        return this.authorities;
     }
 
     @Override
     public String getPassword() {
-        return passwordHash;
+        return this.passwordHash;
     }
 
     @Override
     public String getUsername() {
-        // username은 email 기준
-        return email;
+        return this.email;
     }
 
     @Override

--- a/src/main/java/org/aibe4/dodeul/global/security/CustomUserDetailsService.java
+++ b/src/main/java/org/aibe4/dodeul/global/security/CustomUserDetailsService.java
@@ -1,4 +1,4 @@
-qpackage org.aibe4.dodeul.global.security;
+package org.aibe4.dodeul.global.security;
 
 import lombok.RequiredArgsConstructor;
 import org.aibe4.dodeul.domain.member.model.entity.Member;
@@ -17,12 +17,12 @@ public class CustomUserDetailsService implements UserDetailsService {
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
         Member member =
-                memberRepository
-                        .findByEmail(email)
-                        .orElseThrow(
-                                () -> new UsernameNotFoundException("Member not found: " + email));
+            memberRepository
+                .findByEmail(email)
+                .orElseThrow(
+                    () -> new UsernameNotFoundException("Member not found: " + email));
 
         return new CustomUserDetails(
-                member.getId(), member.getEmail(), member.getPasswordHash(), member.getRole());
+            member.getId(), member.getEmail(), member.getPasswordHash(), member.getRole());
     }
 }


### PR DESCRIPTION
## 관련 이슈
- closed: #27

## 작업 내용
- Spring Security 인증 과정에서 사용할 CustomUserDetails 구현
- 인증 사용자 식별을 위해 memberId를 CustomUserDetails에서 관리
- CustomUserDetailsService를 통해 이메일 기반 사용자 로딩
- 권한을 ROLE_{role} 형태로 매핑

## 체크 리스트
- [x] PR 제목 규칙을 준수했습니다
- [x] 관련 이슈를 연결했습니다
- [x] 본문 내용을 명확하게 작성했습니다
- [x] 정상 작동을 로컬 환경에서 검증했습니다

## 참고사항
본 PR은 CustomUserDetails 및 UserDetailsService 구현까지 포함합니다.
로그인 연동 및 컨트롤러 @AuthenticationPrincipal 적용은 후속 이슈로 분리하여 진행하겠습니다.
OAuth2 로그인은 추후 CustomOAuth2UserService에서 확장 가능하게 연동 예정입니다.