### PR TITLE
[FEAT]: 게시글 목록 조회 API 추가

### DIFF
--- a/src/main/java/org/aibe4/dodeul/domain/board/controller/BoardPostApiController.java
+++ b/src/main/java/org/aibe4/dodeul/domain/board/controller/BoardPostApiController.java
@@ -1,0 +1,92 @@
+// src/main/java/org/aibe4/dodeul/domain/board/controller/BoardPostApiController.java
+package org.aibe4.dodeul.domain.board.controller;
+
+import java.util.List;
+import org.aibe4.dodeul.domain.board.model.dto.BoardPostListPageResponse;
+import org.aibe4.dodeul.domain.board.model.dto.BoardPostListRequest;
+import org.aibe4.dodeul.domain.board.model.dto.BoardPostListResponse;
+import org.aibe4.dodeul.domain.board.service.BoardPostService;
+import org.aibe4.dodeul.domain.consulting.model.enums.ConsultingTag;
+import org.aibe4.dodeul.global.dto.ApiResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/board/posts")
+public class BoardPostApiController {
+
+    private final BoardPostService boardPostService;
+
+    public BoardPostApiController(BoardPostService boardPostService) {
+        this.boardPostService = boardPostService;
+    }
+
+    /**
+     * 게시글 목록 조회
+     *
+     * <p>임시 규칙: Authorization 헤더가 "Bearer {memberId}" 형태면 memberId로 간주한다.
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponse<BoardPostListPageResponse>> listPosts(
+            @RequestHeader(value = "Authorization", required = false) String authorization,
+            @RequestParam(value = "consultingTag", required = false) ConsultingTag consultingTag,
+            @RequestParam(value = "tagIds", required = false) List<Long> tagIds,
+            @RequestParam(value = "status", required = false) String status,
+            @RequestParam(value = "sort", required = false, defaultValue = "LATEST") String sort,
+            @RequestParam(value = "keyword", required = false) String keyword,
+            @RequestParam(value = "page", required = false, defaultValue = "0") Integer page,
+            @RequestParam(value = "size", required = false, defaultValue = "20") Integer size) {
+
+        Long memberId = parseMemberIdFromAuthorization(authorization);
+
+        BoardPostListRequest request =
+                BoardPostListRequest.builder()
+                        .consultingTag(consultingTag)
+                        .skillTagIds(tagIds)
+                        .status(status)
+                        .keyword(keyword)
+                        .sort(sort)
+                        .build();
+
+        Pageable pageable = PageRequest.of(page, size, toSpringSort(sort));
+        Page<BoardPostListResponse> result = boardPostService.getPosts(request, memberId, pageable);
+
+        BoardPostListPageResponse data = BoardPostListPageResponse.from(result);
+        return ResponseEntity.ok(ApiResponse.success("게시글 목록 조회 성공", data));
+    }
+
+    private Sort toSpringSort(String sort) {
+        if (sort == null || sort.isBlank() || "LATEST".equalsIgnoreCase(sort)) {
+            return Sort.by(Sort.Direction.DESC, "createdAt");
+        }
+
+        if ("VIEWS".equalsIgnoreCase(sort)) {
+            return Sort.by(Sort.Direction.DESC, "viewCount")
+                    .and(Sort.by(Sort.Direction.DESC, "createdAt"));
+        }
+
+        if ("ACTIVE".equalsIgnoreCase(sort)) {
+            return Sort.by(Sort.Direction.DESC, "lastCommentedAt")
+                    .and(Sort.by(Sort.Direction.DESC, "createdAt"));
+        }
+
+        return Sort.by(Sort.Direction.DESC, "createdAt");
+    }
+
+    private Long parseMemberIdFromAuthorization(String authorization) {
+        if (authorization == null || !authorization.startsWith("Bearer ")) {
+            return null;
+        }
+
+        String token = authorization.substring("Bearer ".length()).trim();
+        try {
+            return Long.parseLong(token);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/org/aibe4/dodeul/domain/board/model/dto/BoardPostListPageResponse.java
+++ b/src/main/java/org/aibe4/dodeul/domain/board/model/dto/BoardPostListPageResponse.java
@@ -1,0 +1,31 @@
+package org.aibe4.dodeul.domain.board.model.dto;
+
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class BoardPostListPageResponse {
+
+    private final List<BoardPostListResponse> content;
+    private final int page;
+    private final int size;
+    private final long totalElements;
+    private final int totalPages;
+    private final boolean first;
+    private final boolean last;
+
+    public static BoardPostListPageResponse from(Page<BoardPostListResponse> pageResult) {
+        return new BoardPostListPageResponse(
+                pageResult.getContent(),
+                pageResult.getNumber(),
+                pageResult.getSize(),
+                pageResult.getTotalElements(),
+                pageResult.getTotalPages(),
+                pageResult.isFirst(),
+                pageResult.isLast());
+    }
+}

--- a/src/main/java/org/aibe4/dodeul/domain/board/model/dto/BoardPostListRequest.java
+++ b/src/main/java/org/aibe4/dodeul/domain/board/model/dto/BoardPostListRequest.java
@@ -1,0 +1,27 @@
+// src/main/java/org/aibe4/dodeul/domain/board/model/dto/BoardPostListRequest.java
+package org.aibe4.dodeul.domain.board.model.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.aibe4.dodeul.domain.consulting.model.enums.ConsultingTag;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BoardPostListRequest {
+
+    private ConsultingTag consultingTag;
+    private List<Long> skillTagIds;
+
+    // 없거나 잘못되면 OPEN
+    private String status;
+
+    private String keyword;
+
+    // LATEST / VIEWS / ACTIVE
+    private String sort;
+}

--- a/src/main/java/org/aibe4/dodeul/domain/board/model/dto/BoardPostListResponse.java
+++ b/src/main/java/org/aibe4/dodeul/domain/board/model/dto/BoardPostListResponse.java
@@ -1,0 +1,30 @@
+// src/main/java/org/aibe4/dodeul/domain/board/model/dto/BoardPostListResponse.java
+package org.aibe4.dodeul.domain.board.model.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.aibe4.dodeul.domain.consulting.model.enums.ConsultingTag;
+
+/** 게시글 목록 아이템 DTO */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BoardPostListResponse {
+
+    private Long postId;
+    private ConsultingTag consultingTag;
+    private String title;
+    private String postStatus;
+    private long viewCount;
+    private long scrapCount;
+    private long commentCount;
+    private LocalDateTime lastCommentedAt;
+    private LocalDateTime createdAt;
+    private boolean scrappedByMe;
+    private List<String> skillTags;
+}

--- a/src/main/java/org/aibe4/dodeul/domain/board/model/entity/BoardComment.java
+++ b/src/main/java/org/aibe4/dodeul/domain/board/model/entity/BoardComment.java
@@ -6,6 +6,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.aibe4.dodeul.domain.board.model.enums.CommentStatus;
 import org.aibe4.dodeul.domain.common.model.entity.BaseEntity;
 
 // import org.aibe4.dodeul.domain.member.model.entity.Member;

--- a/src/main/java/org/aibe4/dodeul/domain/board/model/entity/BoardPost.java
+++ b/src/main/java/org/aibe4/dodeul/domain/board/model/entity/BoardPost.java
@@ -1,3 +1,4 @@
+// src/main/java/org/aibe4/dodeul/domain/board/model/entity/BoardPost.java
 package org.aibe4.dodeul.domain.board.model.entity;
 
 import jakarta.persistence.*;
@@ -6,7 +7,9 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.aibe4.dodeul.domain.board.model.enums.PostStatus;
 import org.aibe4.dodeul.domain.common.model.entity.BaseEntity;
+import org.aibe4.dodeul.domain.consulting.model.enums.ConsultingTag;
 
 // import org.aibe4.dodeul.domain.member.model.entity.Member;
 
@@ -34,8 +37,9 @@ public class BoardPost extends BaseEntity {
     @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "board_consulting", nullable = false, length = 30)
-    private String boardConsulting;
+    private ConsultingTag boardConsulting;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "post_status", nullable = false, length = 20)
@@ -57,7 +61,7 @@ public class BoardPost extends BaseEntity {
     private LocalDateTime deletedAt;
 
     @Builder
-    public BoardPost(Long memberId, String title, String content, String boardConsulting) {
+    public BoardPost(Long memberId, String title, String content, ConsultingTag boardConsulting) {
         this.memberId = memberId;
         this.title = title;
         this.content = content;
@@ -68,7 +72,7 @@ public class BoardPost extends BaseEntity {
         this.commentCount = 0;
     }
 
-    public void update(String title, String content, String boardConsulting) {
+    public void update(String title, String content, ConsultingTag boardConsulting) {
         validateNotDeleted();
         this.title = title;
         this.content = content;

--- a/src/main/java/org/aibe4/dodeul/domain/board/model/enums/CommentStatus.java
+++ b/src/main/java/org/aibe4/dodeul/domain/board/model/enums/CommentStatus.java
@@ -1,4 +1,4 @@
-package org.aibe4.dodeul.domain.board.model.entity;
+package org.aibe4.dodeul.domain.board.model.enums;
 
 public enum CommentStatus {
     PUBLISHED,

--- a/src/main/java/org/aibe4/dodeul/domain/board/model/enums/PostStatus.java
+++ b/src/main/java/org/aibe4/dodeul/domain/board/model/enums/PostStatus.java
@@ -1,4 +1,4 @@
-package org.aibe4.dodeul.domain.board.model.entity;
+package org.aibe4.dodeul.domain.board.model.enums;
 
 public enum PostStatus {
     OPEN,

--- a/src/main/java/org/aibe4/dodeul/domain/board/repository/BoardPostRepository.java
+++ b/src/main/java/org/aibe4/dodeul/domain/board/repository/BoardPostRepository.java
@@ -1,0 +1,9 @@
+package org.aibe4.dodeul.domain.board.repository;
+
+import org.aibe4.dodeul.domain.board.model.entity.BoardPost;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BoardPostRepository
+        extends JpaRepository<BoardPost, Long>, BoardPostRepositoryCustom {}

--- a/src/main/java/org/aibe4/dodeul/domain/board/repository/BoardPostRepositoryCustom.java
+++ b/src/main/java/org/aibe4/dodeul/domain/board/repository/BoardPostRepositoryCustom.java
@@ -1,0 +1,11 @@
+package org.aibe4.dodeul.domain.board.repository;
+
+import org.aibe4.dodeul.domain.board.model.dto.BoardPostListRequest;
+import org.aibe4.dodeul.domain.board.model.dto.BoardPostListResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface BoardPostRepositoryCustom {
+    Page<BoardPostListResponse> findPosts(
+            BoardPostListRequest request, Long memberId, Pageable pageable);
+}

--- a/src/main/java/org/aibe4/dodeul/domain/board/repository/BoardPostRepositoryImpl.java
+++ b/src/main/java/org/aibe4/dodeul/domain/board/repository/BoardPostRepositoryImpl.java
@@ -1,0 +1,196 @@
+// src/main/java/org/aibe4/dodeul/domain/board/repository/BoardPostRepositoryImpl.java
+package org.aibe4.dodeul.domain.board.repository;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.TypedQuery;
+import jakarta.persistence.criteria.*;
+import java.util.*;
+import java.util.stream.Collectors;
+import org.aibe4.dodeul.domain.board.model.dto.BoardPostListRequest;
+import org.aibe4.dodeul.domain.board.model.dto.BoardPostListResponse;
+import org.aibe4.dodeul.domain.board.model.entity.BoardPost;
+import org.aibe4.dodeul.domain.board.model.entity.BoardPostTagRelation;
+import org.aibe4.dodeul.domain.board.model.enums.PostStatus;
+import org.aibe4.dodeul.domain.consulting.model.enums.ConsultingTag;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+@Transactional(readOnly = true)
+public class BoardPostRepositoryImpl implements BoardPostRepositoryCustom {
+
+    private final EntityManager em;
+
+    public BoardPostRepositoryImpl(EntityManager em) {
+        this.em = em;
+    }
+
+    @Override
+    public Page<BoardPostListResponse> findPosts(
+            BoardPostListRequest request, Long memberId, Pageable pageable) {
+
+        CriteriaBuilder cb = em.getCriteriaBuilder();
+
+        CriteriaQuery<Long> countQuery = cb.createQuery(Long.class);
+        Root<BoardPost> countRoot = countQuery.from(BoardPost.class);
+
+        List<Predicate> countPredicates = buildPredicates(cb, countQuery, countRoot, request);
+        countQuery.select(cb.countDistinct(countRoot));
+        if (!countPredicates.isEmpty()) {
+            countQuery.where(cb.and(countPredicates.toArray(new Predicate[0])));
+        }
+
+        Long total = em.createQuery(countQuery).getSingleResult();
+        if (total == 0) {
+            return new PageImpl<>(Collections.emptyList(), pageable, 0);
+        }
+
+        CriteriaQuery<BoardPost> dataQuery = cb.createQuery(BoardPost.class).distinct(true);
+        Root<BoardPost> root = dataQuery.from(BoardPost.class);
+
+        List<Predicate> predicates = buildPredicates(cb, dataQuery, root, request);
+        if (!predicates.isEmpty()) {
+            dataQuery.where(cb.and(predicates.toArray(new Predicate[0])));
+        }
+
+        if (pageable.getSort().isSorted()) {
+            List<Order> orders = new ArrayList<>();
+            for (Sort.Order o : pageable.getSort()) {
+                if (o.isAscending()) {
+                    orders.add(cb.asc(root.get(o.getProperty())));
+                } else {
+                    orders.add(cb.desc(root.get(o.getProperty())));
+                }
+            }
+            dataQuery.orderBy(orders);
+        } else {
+            dataQuery.orderBy(cb.desc(root.get("createdAt")));
+        }
+
+        TypedQuery<BoardPost> typedQuery = em.createQuery(dataQuery);
+        typedQuery.setFirstResult((int) pageable.getOffset());
+        typedQuery.setMaxResults(pageable.getPageSize());
+
+        List<BoardPost> posts = typedQuery.getResultList();
+        List<Long> postIds = posts.stream().map(BoardPost::getId).collect(Collectors.toList());
+
+        final Set<Long> scrappedPostIds;
+        if (memberId != null && !postIds.isEmpty()) {
+            TypedQuery<Long> q =
+                    em.createQuery(
+                            "select s.boardPost.id "
+                                    + "from BoardPostScrap s "
+                                    + "where s.memberId = :memberId "
+                                    + "and s.boardPost.id in :postIds",
+                            Long.class);
+            q.setParameter("memberId", memberId);
+            q.setParameter("postIds", postIds);
+            scrappedPostIds = new HashSet<>(q.getResultList());
+        } else {
+            scrappedPostIds = Collections.emptySet();
+        }
+
+        Map<Long, List<String>> tagMap = new HashMap<>();
+        if (!postIds.isEmpty()) {
+            TypedQuery<Object[]> relQ =
+                    em.createQuery(
+                            "select r.boardPost.id, r.skillTagEntity.name "
+                                    + "from BoardPostTagRelation r "
+                                    + "where r.boardPost.id in :postIds",
+                            Object[].class);
+            relQ.setParameter("postIds", postIds);
+
+            for (Object[] row : relQ.getResultList()) {
+                Long postId = ((Number) row[0]).longValue();
+                String tagName = (String) row[1];
+                if (tagName == null) {
+                    continue;
+                }
+                tagMap.computeIfAbsent(postId, k -> new ArrayList<>()).add(tagName);
+            }
+        }
+
+        List<BoardPostListResponse> dtos =
+                posts.stream()
+                        .map(
+                                p ->
+                                        BoardPostListResponse.builder()
+                                                .postId(p.getId())
+                                                .consultingTag(p.getBoardConsulting())
+                                                .title(p.getTitle())
+                                                .postStatus(
+                                                        p.getPostStatus() != null
+                                                                ? p.getPostStatus().name()
+                                                                : null)
+                                                .viewCount(
+                                                        p.getViewCount() != null
+                                                                ? p.getViewCount()
+                                                                : 0)
+                                                .scrapCount(
+                                                        p.getScrapCount() != null
+                                                                ? p.getScrapCount()
+                                                                : 0)
+                                                .commentCount(
+                                                        p.getCommentCount() != null
+                                                                ? p.getCommentCount()
+                                                                : 0)
+                                                .lastCommentedAt(p.getLastCommentedAt())
+                                                .createdAt(p.getCreatedAt())
+                                                .scrappedByMe(scrappedPostIds.contains(p.getId()))
+                                                .skillTags(
+                                                        tagMap.getOrDefault(
+                                                                p.getId(), Collections.emptyList()))
+                                                .build())
+                        .collect(Collectors.toList());
+
+        return new PageImpl<>(dtos, pageable, total);
+    }
+
+    private List<Predicate> buildPredicates(
+            CriteriaBuilder cb,
+            CriteriaQuery<?> query,
+            Root<BoardPost> root,
+            BoardPostListRequest request) {
+
+        List<Predicate> predicates = new ArrayList<>();
+
+        PostStatus status = PostStatus.OPEN;
+        if (request.getStatus() != null && !request.getStatus().isBlank()) {
+            try {
+                status = PostStatus.valueOf(request.getStatus().trim().toUpperCase());
+            } catch (IllegalArgumentException e) {
+                // 잘못된 상태 값이 들어온 경우 기본 OPEN 유지
+            }
+        }
+        predicates.add(cb.equal(root.get("postStatus"), status));
+
+        ConsultingTag consultingTag = request.getConsultingTag();
+        if (consultingTag != null) {
+            predicates.add(cb.equal(root.get("boardConsulting"), consultingTag));
+        }
+
+        if (request.getKeyword() != null && !request.getKeyword().isBlank()) {
+            String kw = "%" + request.getKeyword().trim() + "%";
+            predicates.add(cb.or(cb.like(root.get("title"), kw), cb.like(root.get("content"), kw)));
+        }
+
+        if (request.getSkillTagIds() != null && !request.getSkillTagIds().isEmpty()) {
+            Subquery<Integer> sub = query.subquery(Integer.class);
+            Root<BoardPostTagRelation> rel = sub.from(BoardPostTagRelation.class);
+
+            Predicate p1 = cb.equal(rel.get("boardPost").get("id"), root.get("id"));
+            Predicate p2 = rel.get("skillTagEntity").get("id").in(request.getSkillTagIds());
+
+            sub.select(cb.literal(1));
+            sub.where(cb.and(p1, p2));
+
+            predicates.add(cb.exists(sub));
+        }
+
+        return predicates;
+    }
+}

--- a/src/main/java/org/aibe4/dodeul/domain/board/service/BoardPostService.java
+++ b/src/main/java/org/aibe4/dodeul/domain/board/service/BoardPostService.java
@@ -1,0 +1,24 @@
+// src/main/java/org/aibe4/dodeul/domain/board/service/BoardPostService.java
+package org.aibe4.dodeul.domain.board.service;
+
+import lombok.RequiredArgsConstructor;
+import org.aibe4.dodeul.domain.board.model.dto.BoardPostListRequest;
+import org.aibe4.dodeul.domain.board.model.dto.BoardPostListResponse;
+import org.aibe4.dodeul.domain.board.repository.BoardPostRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BoardPostService {
+
+    private final BoardPostRepository boardPostRepository;
+
+    public Page<BoardPostListResponse> getPosts(
+            BoardPostListRequest request, Long memberId, Pageable pageable) {
+        return boardPostRepository.findPosts(request, memberId, pageable);
+    }
+}

--- a/src/main/java/org/aibe4/dodeul/domain/member/model/entity/Member.java
+++ b/src/main/java/org/aibe4/dodeul/domain/member/model/entity/Member.java
@@ -12,7 +12,6 @@ import org.aibe4.dodeul.domain.member.model.enums.Role;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity(name = "members")
-
 public class Member extends BaseEntity {
 
     @Column(nullable = false, length = 255, unique = true)

--- a/src/main/java/org/aibe4/dodeul/global/security/SecurityConfig.java
+++ b/src/main/java/org/aibe4/dodeul/global/security/SecurityConfig.java
@@ -1,5 +1,6 @@
 package org.aibe4.dodeul.global.security;
 
+import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
@@ -7,9 +8,9 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.web.cors.*;
-
-import java.util.List;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
 public class SecurityConfig {
@@ -26,51 +27,56 @@ public class SecurityConfig {
                 .cors(Customizer.withDefaults())
 
                 // CSRF: UI는 보호, API는 제외(개발 편의)
-                .csrf(csrf -> csrf
-                        .ignoringRequestMatchers("/api/**")
-                )
+                .csrf(csrf -> csrf.ignoringRequestMatchers("/api/**"))
 
                 // URL 권한
-                .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(
-                                "/", "/error",
-                                "/css/**", "/js/**", "/images/**", "/favicon.ico",
-                                "/auth/**",
-                                "/api/auth/**",
-
-                                "/swagger-ui.html",
-                                "/swagger-ui/**",
-                                "/v3/api-docs/**",
-
-                                "/oauth2/**",
-                                "/login/oauth2/**",
-                                "/login",
-                                "/h2-console/**"
-                        ).permitAll()
-                        .requestMatchers("/mypage/**", "/api/**").authenticated()
-                        .anyRequest().authenticated()
-                )
+                .authorizeHttpRequests(
+                        auth ->
+                                auth.requestMatchers(
+                                                "/",
+                                                "/error",
+                                                "/css/**",
+                                                "/js/**",
+                                                "/images/**",
+                                                "/favicon.ico",
+                                                "/auth/**",
+                                                "/api/auth/**",
+                                                "/swagger-ui.html",
+                                                "/swagger-ui/**",
+                                                "/v3/api-docs/**",
+                                                "/oauth2/**",
+                                                "/login/oauth2/**",
+                                                "/login",
+                                                "/h2-console/**",
+                                                "/api/board/posts",
+                                                "/api/board/posts/**")
+                                        .permitAll()
+                                        .requestMatchers("/mypage/**", "/api/**")
+                                        .authenticated()
+                                        .anyRequest()
+                                        .authenticated())
 
                 // 세션 관리
-                .sessionManagement(session -> session
-                        .sessionFixation(sessionFixation -> sessionFixation.migrateSession())
-                        .invalidSessionUrl("/auth/login?expired")
-                )
+                .sessionManagement(
+                        session ->
+                                session.sessionFixation(
+                                                sessionFixation -> sessionFixation.migrateSession())
+                                        .invalidSessionUrl("/auth/login?expired"))
 
                 // 로그인/로그아웃
-                .formLogin(form -> form
-                        .loginPage("/auth/login")
-                        .loginProcessingUrl("/login")
-                        .defaultSuccessUrl("/mypage/dashboard", true)
-                        .permitAll()
-                )
-                .logout(logout -> logout
-                        .logoutUrl("/logout")
-                        .invalidateHttpSession(true)
-                        .deleteCookies("JSESSIONID")
-                        .logoutSuccessUrl("/auth/login")
-                );
-        //H2 console iframe 차단 방지
+                .formLogin(
+                        form ->
+                                form.loginPage("/auth/login")
+                                        .loginProcessingUrl("/login")
+                                        .defaultSuccessUrl("/mypage/dashboard", true)
+                                        .permitAll())
+                .logout(
+                        logout ->
+                                logout.logoutUrl("/logout")
+                                        .invalidateHttpSession(true)
+                                        .deleteCookies("JSESSIONID")
+                                        .logoutSuccessUrl("/auth/login"));
+        // H2 console iframe 차단 방지
         http.headers(headers -> headers.frameOptions(frame -> frame.sameOrigin()));
 
         return http.build();
@@ -90,4 +96,3 @@ public class SecurityConfig {
         return source;
     }
 }
-


### PR DESCRIPTION
- GET /api/board/posts 목록 조회 API 추가
- 목록 조회 요청/응답 DTO 및 페이지 응답 DTO 구성
- 정렬(LATEST / VIEWS / ACTIVE), 페이징, 필터링 파라미터 처리
- Repository 커스텀 구현으로 목록 조회 쿼리 분리
- 게시글 목록 조회 API 공개 접근(Security 설정) 반영
- consultingTag 필터 누락 문제 수정 및 enum 기반 필터링 적용
- ConsultingTagDto 제거 후 ConsultingTag(enum) 사용하도록 구조 개선
- BoardPost.boardConsulting 필드를 ConsultingTag 타입으로 변경 및 @Enumerated 적용
- BoardPostListRequest에서 consultingTagId 제거, ConsultingTag 필드로 대체
- BoardPostListRequest에서 page, size 필드 제거 (Pageable 기반 처리)

#11

## 관련 이슈
- closed: #11

## 작업 내용
- 게시글 목록 조회 API 구현
- Criteria 기반 동적 쿼리로 상태 / 상담분야 / 태그 / 키워드 필터링 처리
- 도메인 enum 통일로 타입 안정성 개선
- API / View 경로 분리 규칙에 맞춰 API URL 수정

## 체크 리스트
- [x] PR 제목 규칙을 준수했습니다
- [x] 관련 이슈를 연결했습니다
- [x] 본문 내용을 명확하게 작성했습니다
- [x] 정상 작동을 로컬 환경에서 검증했습니다

## 리뷰어에게
- 코드리뷰에서 지적해주신 consultingTag 필터 누락 및 DTO/enum 구조 관련 사항을 모두 반영했습니다.
- API는 JSON 기반으로 `/api/board/posts` 경로에서 제공합니다.

## 연관 이슈
- #11
