### PR TITLE
[REFACTOR] JobTag / SkillTag BaseEntity 상속 제거

### DIFF
--- a/src/main/java/org/aibe4/dodeul/domain/common/model/entity/JobTag.java
+++ b/src/main/java/org/aibe4/dodeul/domain/common/model/entity/JobTag.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "job_tags")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class JobTag extends BaseEntity {
+public class JobTag {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/org/aibe4/dodeul/domain/common/model/entity/SkillTag.java
+++ b/src/main/java/org/aibe4/dodeul/domain/common/model/entity/SkillTag.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "skill_tags")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class SkillTag extends BaseEntity {
+public class SkillTag {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
- JobTag, SkillTag 엔티티에서 BaseEntity 상속 제거
- 태그 도메인은 생성/수정일 관리가 불필요하여 공통 BaseEntity 사용 제거
- BaseEntity 내 id 필드와의 중복 선언 구조 정리
- 단순 참조용 태그 엔티티 책임 명확화

#34

## 관련 이슈
- closed: #34

## 작업 내용
- JobTag 엔티티에서 BaseEntity 상속 제거
- SkillTag 엔티티에서 BaseEntity 상속 제거
- 중복된 id 선언 구조 정리

## 체크 리스트
- [x] PR 제목 규칙을 준수했습니다
- [x] 관련 이슈를 연결했습니다
- [x] 본문 내용을 명확하게 작성했습니다
- [x] 정상 작동을 로컬 환경에서 검증했습니다

## 연관 이슈
- #34