### PR TITLE
[FEAT] 역할 기반 접근 권한 설정

### DIFF
--- a/src/main/java/org/aibe4/dodeul/domain/demo/controller/AuthController.java
+++ b/src/main/java/org/aibe4/dodeul/domain/demo/controller/AuthController.java
@@ -1,0 +1,13 @@
+package org.aibe4.dodeul.domain.demo.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class AuthController {
+
+    @GetMapping("/auth/login")
+    public String loginPage() {
+        return "demo/auth/demo-login";
+    }
+}

--- a/src/main/java/org/aibe4/dodeul/domain/demo/controller/RoleTestController.java
+++ b/src/main/java/org/aibe4/dodeul/domain/demo/controller/RoleTestController.java
@@ -1,0 +1,22 @@
+q/**
+ * Role-based access control test controller.
+ * For development/testing only.
+ */
+package org.aibe4.dodeul.domain.demo.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class RoleTestController {
+
+    @GetMapping("/mypage/mentor/test")
+    public String mentorOnly() {
+        return "mentor only endpoint";
+    }
+
+    @GetMapping("/mypage/mentee/test")
+    public String menteeOnly() {
+        return "mentee only endpoint";
+    }
+}

--- a/src/main/java/org/aibe4/dodeul/global/security/SecurityConfig.java
+++ b/src/main/java/org/aibe4/dodeul/global/security/SecurityConfig.java
@@ -1,16 +1,20 @@
 package org.aibe4.dodeul.global.security;
 
-import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
 
 @Configuration
 public class SecurityConfig {
@@ -23,59 +27,70 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-                // CORS
-                .cors(Customizer.withDefaults())
+            // CORS
+            .cors(Customizer.withDefaults())
 
-                // CSRF: UI는 보호, API는 제외(개발 편의)
-                .csrf(csrf -> csrf.ignoringRequestMatchers("/api/**"))
+            // CSRF: UI는 보호, API는 제외(개발 편의)
+            .csrf(csrf -> csrf.ignoringRequestMatchers("/api/**"))
 
-                // URL 권한
-                .authorizeHttpRequests(
-                        auth ->
-                                auth.requestMatchers(
-                                                "/",
-                                                "/error",
-                                                "/css/**",
-                                                "/js/**",
-                                                "/images/**",
-                                                "/favicon.ico",
-                                                "/auth/**",
-                                                "/api/auth/**",
-                                                "/swagger-ui.html",
-                                                "/swagger-ui/**",
-                                                "/v3/api-docs/**",
-                                                "/oauth2/**",
-                                                "/login/oauth2/**",
-                                                "/login",
-                                                "/h2-console/**",
-                                                "/api/board/posts",
-                                                "/api/board/posts/**")
-                                        .permitAll()
-                                        .requestMatchers("/mypage/**", "/api/**")
-                                        .authenticated()
-                                        .anyRequest()
-                                        .authenticated())
+            // URL 권한
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers(
+                    "/",
+                    "/error",
+                    "/css/**",
+                    "/js/**",
+                    "/images/**",
+                    "/favicon.ico",
+                    "/auth/**",
+                    "/api/auth/**",
 
-                // 세션 관리
-                .sessionManagement(
-                        session ->
-                                session.sessionFixation(
-                                                sessionFixation -> sessionFixation.migrateSession())
-                                        .invalidSessionUrl("/auth/login?expired"))
+                    "/swagger-ui.html",
+                    "/swagger-ui/**",
+                    "/v3/api-docs/**",
 
-                // 로그인/로그아웃
-                .formLogin(
-                        form ->
-                                form.loginPage("/auth/login")
-                                        .loginProcessingUrl("/login")
-                                        .defaultSuccessUrl("/mypage/dashboard", true)
-                                        .permitAll())
-                .logout(
-                        logout ->
-                                logout.logoutUrl("/logout")
-                                        .invalidateHttpSession(true)
-                                        .deleteCookies("JSESSIONID")
-                                        .logoutSuccessUrl("/auth/login"));
+                    "/oauth2/**",
+                    "/login/oauth2/**",
+                    "/login",
+                    "/h2-console/**",
+
+                    // board 공개 조회 permitAll (dev 최신 반영)
+                    "/api/board/posts",
+                    "/api/board/posts/**"
+                ).permitAll()
+
+                // 역할 기반
+                .requestMatchers("/mypage/mentor/**").hasRole("MENTOR")
+                .requestMatchers("/mypage/mentee/**").hasRole("MENTEE")
+
+                // API 역할 분리 시
+                .requestMatchers("/api/mentor/**").hasRole("MENTOR")
+                .requestMatchers("/api/mentee/**").hasRole("MENTEE")
+
+                .requestMatchers("/mypage/**", "/api/**").authenticated()
+                .anyRequest().authenticated()
+            )
+
+            // 세션 관리
+            .sessionManagement(session -> session
+                .sessionFixation(sessionFixation -> sessionFixation.migrateSession())
+                .invalidSessionUrl("/auth/login?expired")
+            )
+
+            // 로그인/로그아웃
+            .formLogin(form -> form
+                .loginPage("/auth/login")
+                .loginProcessingUrl("/login")
+                .defaultSuccessUrl("/mypage/dashboard", true)
+                .permitAll()
+            )
+            .logout(logout -> logout
+                .logoutUrl("/logout")
+                .invalidateHttpSession(true)
+                .deleteCookies("JSESSIONID")
+                .logoutSuccessUrl("/auth/login")
+            );
+
         // H2 console iframe 차단 방지
         http.headers(headers -> headers.frameOptions(frame -> frame.sameOrigin()));
 
@@ -94,5 +109,20 @@ public class SecurityConfig {
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", config);
         return source;
+    }
+
+    // 멘토/멘티 테스트 계정 (임시)
+    @Bean
+    public UserDetailsService userDetailsService(PasswordEncoder passwordEncoder) {
+        return new InMemoryUserDetailsManager(
+            User.withUsername("mentor@test.com")
+                .password(passwordEncoder.encode("1234"))
+                .roles("MENTOR")
+                .build(),
+            User.withUsername("mentee@test.com")
+                .password(passwordEncoder.encode("1234"))
+                .roles("MENTEE")
+                .build()
+        );
     }
 }

--- a/src/main/resources/templates/demo/auth/demo-login.html
+++ b/src/main/resources/templates/demo/auth/demo-login.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="utf-8"/>
+  <title>데모 로그인</title>
+</head>
+<body>
+<h1>데모 로그인</h1>
+
+<form method="post" action="/login">
+  <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
+
+  <div>
+    <label>Email</label>
+    <input type="text" name="username" autocomplete="username"/>
+  </div>
+
+  <div>
+    <label>Password</label>
+    <input type="password" name="password" autocomplete="current-password"/>
+  </div>
+
+  <button type="submit">Login</button>
+</form>
+
+</body>
+</html>


### PR DESCRIPTION
## 관련 이슈
- closed: #37

## 작업 내용
-- Spring Security `hasRole` 기반 접근 제어 설정
  - `/mypage/mentor/**` → `ROLE_MENTOR`
  - `/mypage/mentee/**` → `ROLE_MENTEE`
  - `/api/mentor/**`, `/api/mentee/**` 역할 분리
- dev 브랜치 최신 변경사항(SecurityConfig, board 공개 API permitAll) 반영
- 역할 검증을 위한 **임시 로그인 환경** 구성
  - InMemoryUserDetailsService 사용 (mentor / mentee 테스트 계정)
  - 데모 로그인 페이지 추가 (`/auth/login`)

테스트 방법
1. `/auth/login` 접속
2. 아래 계정으로 로그인
   - mentor  
     - email: `mentor@test.com`
     - password: `1234`
   - mentee  
     - email: `mentee@test.com`
     - password: `1234`
3. 접근 확인
   - mentor → `/mypage/mentor/**` 접근 가능
   - mentee → `/mypage/mentee/**` 접근 가능
   - 서로 역할이 다른 경로 접근 시 403 발생
  
## 참고 사항
- 본 PR은 **역할 기반 접근 제어(hasRole) 검증 목적**의 작업입니다.
 **아직 머지하지 말아주세요!!**

## 체크 리스트
- [ ] PR 제목 규칙을 준수했습니다
- [ ] 관련 이슈를 연결했습니다
- [ ] 본문 내용을 명확하게 작성했습니다
- [ ] 정상 작동을 로컬 환경에서 검증했습니다