### PR TITLE
[FEAT] 상담 신청 상세 조회 구현

### DIFF
--- a/src/main/java/org/aibe4/dodeul/domain/consulting/controller/ConsultingApplicationController.java
+++ b/src/main/java/org/aibe4/dodeul/domain/consulting/controller/ConsultingApplicationController.java
@@ -3,14 +3,14 @@ package org.aibe4.dodeul.domain.consulting.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.aibe4.dodeul.domain.consulting.model.dto.ConsultingApplicationDetailResponse;
 import org.aibe4.dodeul.domain.consulting.model.dto.ConsultingApplicationRequest;
 import org.aibe4.dodeul.domain.consulting.service.ConsultingApplicationService;
 import org.aibe4.dodeul.global.security.CustomUserDetails;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Consulting Application", description = "상담 신청 관련 컨트롤러")
 @Controller
@@ -37,5 +37,20 @@ public class ConsultingApplicationController {
 
         // 2. 리다이렉션
         return "redirect:/matching/recommend?applicationId=" + savedApplicationId;
+    }
+
+    @Operation(summary = "상담 신청 상세 조회", description = "상담 신청서의 상세 내용을 조회합니다.")
+    @GetMapping("/{applicationId}")
+    public String getApplicationDetail(@PathVariable Long applicationId, Model model) {
+
+        // 1. 서비스에서 상세 내용 가져오기
+        ConsultingApplicationDetailResponse response =
+            consultingApplicationService.getApplicationDetail(applicationId);
+
+        // 2. HTML에 데이터 전달
+        model.addAttribute("application", response);
+
+        // 3. HTML 파일 보여주기
+        return "consulting/application-detail";
     }
 }

--- a/src/main/java/org/aibe4/dodeul/domain/consulting/model/dto/ConsultingApplicationDetailResponse.java
+++ b/src/main/java/org/aibe4/dodeul/domain/consulting/model/dto/ConsultingApplicationDetailResponse.java
@@ -1,0 +1,34 @@
+package org.aibe4.dodeul.domain.consulting.model.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.aibe4.dodeul.domain.consulting.model.entity.ConsultingApplication;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+public class ConsultingApplicationDetailResponse {
+
+    private Long id;
+    private String menteeName;
+    private String title;
+    private String content;
+    private List<String> skillTags;
+    private String fileUrl;
+
+    public static ConsultingApplicationDetailResponse from(ConsultingApplication entity) {
+        return ConsultingApplicationDetailResponse.builder()
+            .id(entity.getId())
+            .menteeName("멘티 ID: " + entity.getMenteeId()) // 멘티 이름 대신 임시로 ID 표시
+            .title(entity.getTitle())
+            .content(entity.getContent())
+            .fileUrl(entity.getFileUrl())
+            // 신청서에 연결된 스킬 태그 이름들을 리스트로 변환
+            .skillTags(entity.getApplicationSkillTags().stream()
+                .map(mapping -> mapping.getSkillTag().getName())
+                .collect(Collectors.toList()))
+            .build();
+    }
+}

--- a/src/main/java/org/aibe4/dodeul/domain/consulting/service/ConsultingApplicationService.java
+++ b/src/main/java/org/aibe4/dodeul/domain/consulting/service/ConsultingApplicationService.java
@@ -1,18 +1,20 @@
 package org.aibe4.dodeul.domain.consulting.service;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.aibe4.dodeul.domain.common.model.entity.SkillTag;
 import org.aibe4.dodeul.domain.common.repository.SkillTagRepository;
+import org.aibe4.dodeul.domain.consulting.model.dto.ConsultingApplicationDetailResponse;
 import org.aibe4.dodeul.domain.consulting.model.dto.ConsultingApplicationRequest;
 import org.aibe4.dodeul.domain.consulting.model.entity.ApplicationSkillTag;
 import org.aibe4.dodeul.domain.consulting.model.entity.ConsultingApplication;
 import org.aibe4.dodeul.domain.consulting.model.repository.ConsultingApplicationRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -22,52 +24,60 @@ public class ConsultingApplicationService {
     private final ConsultingApplicationRepository consultingApplicationRepository;
     private final SkillTagRepository skillTagRepository;
 
+    // ✅ [추가된 부분] 상담 신청서 상세 조회
+    public ConsultingApplicationDetailResponse getApplicationDetail(Long applicationId) {
+        ConsultingApplication application =
+            consultingApplicationRepository
+                .findById(applicationId)
+                .orElseThrow(
+                    () ->
+                        new IllegalArgumentException(
+                            "해당 상담 신청서를 찾을 수 없습니다. id=" + applicationId));
+
+        // 엔티티를 DTO로 변환해서 반환
+        return ConsultingApplicationDetailResponse.from(application);
+    }
+
+    // [기존 코드] 상담 신청서 저장 (변경 없음)
     @Transactional
     public Long saveApplication(ConsultingApplicationRequest request) {
 
-        // 1. DB에서 실제 스킬 태그 객체들을 찾아옵니다. (기존과 동일)
         List<SkillTag> foundSkillTags = new ArrayList<>();
         if (request.getTechTags() != null && !request.getTechTags().isEmpty()) {
             foundSkillTags =
-                    Arrays.stream(request.getTechTags().split(","))
-                            .map(String::trim)
-                            .map(
-                                    tagName ->
-                                            skillTagRepository
-                                                    .findByName(tagName)
-                                                    .orElseThrow(
-                                                            () ->
-                                                                    new IllegalArgumentException(
-                                                                            "존재하지 않는 태그입니다: "
-                                                                                    + tagName)))
-                            .collect(Collectors.toList());
+                Arrays.stream(request.getTechTags().split(","))
+                    .map(String::trim)
+                    .map(
+                        tagName ->
+                            skillTagRepository
+                                .findByName(tagName)
+                                .orElseThrow(
+                                    () ->
+                                        new IllegalArgumentException(
+                                            "존재하지 않는 태그입니다: "
+                                                + tagName)))
+                    .collect(Collectors.toList());
         }
 
-        // 2. 신청서 엔티티 생성 (주의: 여기서는 아직 태그를 넣지 않습니다!)
         ConsultingApplication application =
-                ConsultingApplication.builder()
-                        .menteeId(request.getMenteeId())
-                        .title(request.getTitle())
-                        .content(request.getContent())
-                        .consultingTag(request.getConsultingTag())
-                        .fileUrl(request.getFileUrl())
-                        // .skillTags(skillTags) -> 이 부분은 삭제되었습니다.
-                        .build();
+            ConsultingApplication.builder()
+                .menteeId(request.getMenteeId())
+                .title(request.getTitle())
+                .content(request.getContent())
+                .consultingTag(request.getConsultingTag())
+                .fileUrl(request.getFileUrl())
+                .build();
 
-        // 3. [핵심 변경] 신청서와 스킬태그를 연결하는 '중간 객체'를 만들어 넣어줍니다.
         for (SkillTag skillTag : foundSkillTags) {
-            // 중간 객체 생성 (나 = 신청서, 상대 = 스킬태그)
             ApplicationSkillTag mapping =
-                    ApplicationSkillTag.builder()
-                            .consultingApplication(application)
-                            .skillTag(skillTag)
-                            .build();
+                ApplicationSkillTag.builder()
+                    .consultingApplication(application)
+                    .skillTag(skillTag)
+                    .build();
 
-            // 신청서 안에 있는 편의 메서드를 통해 연결 (아까 만든 addSkillTag 메서드 사용)
             application.addSkillTag(mapping);
         }
 
-        // 4. 신청서를 저장하면, 연결된 중간 객체들도 같이 저장됩니다. (Cascade 옵션 덕분)
         ConsultingApplication savedApplication = consultingApplicationRepository.save(application);
 
         return savedApplication.getId();

--- a/src/main/resources/templates/consulting/application-detail.html
+++ b/src/main/resources/templates/consulting/application-detail.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="ko"
+      xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{common/layout/base}">
+<head>
+  <title>상담 신청 상세</title>
+</head>
+
+<body>
+<section layout:fragment="content">
+  <div class="container py-5" style="max-width: 900px;">
+
+    <div class="mb-4 border-bottom pb-2">
+      <h4 class="fw-bold">◇ 상담 신청 상세</h4>
+    </div>
+
+    <div class="card shadow-sm mb-5">
+      <div class="card-body p-4 d-flex align-items-center">
+        <div class="rounded-circle bg-secondary d-flex justify-content-center align-items-center text-white me-3"
+             style="width: 60px; height: 60px; font-size: 1.5rem;">
+          <i class="bi bi-person"></i> 👤
+        </div>
+        <div>
+          <h5 class="mb-1 fw-bold" th:text="${application.menteeName}">멘티 ID</h5>
+          <small class="text-muted">상담 신청자</small>
+        </div>
+      </div>
+    </div>
+
+    <div class="text-center mb-4">
+      <span class="fw-bold text-dark">답변 대기중</span>
+    </div>
+
+    <div class="card shadow-sm border-0 bg-light bg-opacity-10">
+      <div class="card-body p-5 border">
+
+        <h3 class="fw-bold mb-4" th:text="${application.title}">
+          제목 예시
+        </h3>
+
+        <div class="mb-5 text-dark" style="white-space: pre-wrap; line-height: 1.8;"
+             th:text="${application.content}">
+          내용 예시
+        </div>
+
+        <div class="mb-5">
+            <span th:each="tag : ${application.skillTags}"
+                  class="badge rounded-pill text-bg-secondary me-2 px-3 py-2 fw-normal"
+                  style="background-color: #6c757d !important;"
+                  th:text="${tag}">
+                Java
+            </span>
+        </div>
+
+        <hr class="text-secondary opacity-25">
+
+        <div class="mt-4">
+          <span class="me-2">📎</span>
+
+          <a th:if="${application.fileUrl != null}"
+             th:href="${application.fileUrl}"
+             class="text-decoration-none text-dark fw-bold"
+             download>
+            <span th:text="${application.fileUrl}">첨부파일_링크</span>
+          </a>
+
+          <span th:unless="${application.fileUrl != null}" class="text-muted small">
+             첨부된 파일이 없습니다.
+          </span>
+        </div>
+
+      </div>
+    </div>
+
+    <div class="d-flex justify-content-end gap-2 mt-4">
+      <button type="button" class="btn btn-outline-secondary px-4">수정하기</button>
+      <button type="button" class="btn btn-outline-secondary px-4">취소하기</button>
+      <a href="/consulting-applications" class="btn btn-outline-dark px-4">목록으로</a>
+    </div>
+
+  </div>
+</section>
+</body>
+</html>


### PR DESCRIPTION
## 관련 이슈
- Closes #56

## 작업 내용
- 상세 조회 기능 구현: 상담 신청서 ID로 상세 정보를 조회하는 기능 추가
- DTO 추가: 화면 렌더링에 필요한 `ConsultingApplicationDetailResponse` 구현
- View 구현: 타임리프(Thymeleaf)를 활용한 상세 페이지(`application-detail.html`) 제작

## 체크 리스트
- [x] PR 제목 규칙을 준수했습니다
- [x] 관련 이슈를 연결했습니다
- [x] 본문 내용을 명확하게 작성했습니다
- [x] 정상 작동을 로컬 환경에서 검증했습니다

## 리뷰어에게
- 상세 페이지는 기존 `base.html` 레이아웃을 상속받아 통일성을 유지했습니다.