### PR TITLE
[FEAT] 멤버-스킬, 멤버-상담분야 매핑 엔티티 추가

### DIFF
--- a/src/main/java/org/aibe4/dodeul/domain/member/model/entity/Member.java
+++ b/src/main/java/org/aibe4/dodeul/domain/member/model/entity/Member.java
@@ -9,6 +9,9 @@ import org.aibe4.dodeul.domain.common.model.entity.BaseEntity;
 import org.aibe4.dodeul.domain.member.model.enums.Provider;
 import org.aibe4.dodeul.domain.member.model.enums.Role;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity(name = "members")
@@ -39,6 +42,12 @@ public class Member extends BaseEntity {
 
     @Column(nullable = false, length = 20, unique = true)
     private String nickname;
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MemberConsultingTag> consultingTags = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MemberSkillTag> skillTags = new ArrayList<>();
 
     @Builder
     private Member(

--- a/src/main/java/org/aibe4/dodeul/domain/member/model/entity/MemberConsultingTag.java
+++ b/src/main/java/org/aibe4/dodeul/domain/member/model/entity/MemberConsultingTag.java
@@ -1,0 +1,39 @@
+package org.aibe4.dodeul.domain.member.model.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.aibe4.dodeul.domain.consulting.model.enums.ConsultingTag;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+    name = "member_consulting_tags",
+    uniqueConstraints = {
+        @UniqueConstraint(
+            name = "uk_member_consulting_tags",
+            columnNames = {"member_id", "consulting_name"}
+        )
+    }
+)
+public class MemberConsultingTag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "consulting_name", nullable = false)
+    private ConsultingTag consultingTag;
+
+    public MemberConsultingTag(Member member, ConsultingTag consultingTag) {
+        this.member = member;
+        this.consultingTag = consultingTag;
+    }
+}

--- a/src/main/java/org/aibe4/dodeul/domain/member/model/entity/MemberSkillTag.java
+++ b/src/main/java/org/aibe4/dodeul/domain/member/model/entity/MemberSkillTag.java
@@ -1,0 +1,39 @@
+package org.aibe4.dodeul.domain.member.model.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.aibe4.dodeul.domain.common.model.entity.SkillTag;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+    name = "member_skill_tags",
+    uniqueConstraints = {
+        @UniqueConstraint(
+            name = "uk_member_skill_tags",
+            columnNames = {"member_id", "skill_id"}
+        )
+    }
+)
+public class MemberSkillTag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "skill_id", nullable = false)
+    private SkillTag skillTag;
+
+    public MemberSkillTag(Member member, SkillTag skillTag) {
+        this.member = member;
+        this.skillTag = skillTag;
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- closed: #115 

## 작업 내용
- 멤버-스킬, 멤버-상담분야 매핑 엔티티 추가

## 체크 리스트
- [x] PR 제목 규칙을 준수했습니다
- [x] 관련 이슈를 연결했습니다
- [x] 본문 내용을 명확하게 작성했습니다
- [x] 정상 작동을 로컬 환경에서 검증했습니다

## 리뷰어에게
- member_consulting_tags 테이블이 복합키 대신 별도의 id를 가지를 가지도록 변경하였습니다.