### PR TITLE
[FEAT] 상담 신청서 파일 첨부 기능 구현

### DIFF
--- a/src/main/java/org/aibe4/dodeul/domain/consulting/model/dto/ConsultingApplicationRequest.java
+++ b/src/main/java/org/aibe4/dodeul/domain/consulting/model/dto/ConsultingApplicationRequest.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.aibe4.dodeul.domain.consulting.model.enums.ConsultingTag;
+import org.springframework.web.multipart.MultipartFile;
 
 @Getter
 @Setter
@@ -29,6 +30,9 @@ public class ConsultingApplicationRequest {
     @NotBlank(message = "기술 태그를 입력해주세요.") // 예: "Java, Spring" (필수라면 NotBlank)
     private String techTags;
 
+    // HTML의 <input name="file">과 이름이 같아야 합니다.
+    private MultipartFile file;
+    
     // 파일은 아직 기능 구현 전이므로 검증 제외 (선택 사항)
     private String fileUrl;
 }

--- a/src/main/resources/templates/consulting/application-form.html
+++ b/src/main/resources/templates/consulting/application-form.html
@@ -69,7 +69,7 @@
       </div>
     </div>
 
-    <form th:action="${formActionUrl}" th:object="${request}" method="post">
+    <form th:action="${formActionUrl}" th:object="${request}" method="post" enctype="multipart/form-data">
 
       <div class="mb-5">
         <h4 class="fw-bold mb-2">카테고리 선택</h4>
@@ -103,13 +103,13 @@
       </div>
 
       <div class="mb-4">
-        <label class="fw-bold mb-2">상담 제목</label>
+        <label class="fw-bold mb-2">상담 제목 （필수）</label>
         <input type="text" class="form-control p-3" th:field="*{title}"
                placeholder="멘토링 상담 제목을 입력하세요" required>
       </div>
 
       <div class="mb-4">
-        <label class="fw-bold mb-2">상담 내용</label>
+        <label class="fw-bold mb-2">상담 내용 （필수）</label>
         <textarea id="content" class="form-control p-3" th:field="*{content}" rows="6"
                   placeholder="상담 받고 싶은 내용과 목표를 상세하게 작성해주세요."
                   required oninput="updateCharCount(this)"></textarea>
@@ -117,15 +117,16 @@
       </div>
 
       <div class="mb-4">
-        <label class="fw-bold mb-2">스킬 태그</label>
+        <label class="fw-bold mb-2">스킬 태그 （필수）</label>
         <input type="text" class="form-control p-3" th:field="*{techTags}"
                placeholder="예: Java, React, PM (쉼표로 구분)">
       </div>
 
       <div class="mb-5">
-        <label class="fw-bold mb-2">첨부파일</label>
-        <input type="text" class="form-control" th:field="*{fileUrl}"
-               placeholder="파일 URL을 입력하세요">
+        <label class="fw-bold mb-2">첨부파일 （선택）</label>
+        <input type="file" id="file" name="file" class="form-control"
+               accept=".jpg,.jpeg,.png,.gif,.pdf,.txt,.ppt,.pptx">
+        <div class="form-text text-muted small">이미지, PDF, PPT 등 최대 5MB까지 첨부 가능합니다.</div>
       </div>
 
       <hr class="my-5">


### PR DESCRIPTION
## 관련 이슈
- closed: #117 

## 작업 내용
- application-dev.yml 내 파일 업로드 용량 제한 설정 (5MB)
- ConsultingApplicationRequest DTO 내 MultipartFile 필드 추가
- 상담 신청 작성 폼 HTML 수정 (enctype 추가 및 파일 입력 필드 구현)
- ConsultingApplicationService 내 임시 파일 저장 로직 및 UUID 기반 파일명 생성 기능 추가
- 신청서 수정(update) 시 신규 파일 교체 로직 적용


## 체크 리스트
- [x] PR 제목 규칙을 준수했습니다
- [x] 관련 이슈를 연결했습니다
- [x] 본문 내용을 명확하게 작성했습니다
- [x] 정상 작동을 로컬 환경에서 검증했습니다


## 리뷰어에게
- 상담 신청서 작성 시 참고 자료를 첨부할 수 있는 기능을 구현했습니다.
- 현재는 로컬 서버(`C:/dodeul/uploads/`)에 저장되는 방식이며, 내일 파일 공통 컨텍스트가 생성되면 ConsultingApplicationService 내의 uploadFile 메서드를 공통 서비스로 교체할 수 있도록 로직을 분리해 두었습니다.

