### PR TITLE
[FEAT] 마이페이지 프로필 수정 및 이미지 업로드 기능 구현

### DIFF
--- a/src/main/java/org/aibe4/dodeul/domain/common/model/entity/SkillTag.java
+++ b/src/main/java/org/aibe4/dodeul/domain/common/model/entity/SkillTag.java
@@ -14,7 +14,7 @@ public class SkillTag {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "skill_tag_id")
+    @Column(name = "id")
     private Long id;
 
     @Column(nullable = false, unique = true)

--- a/src/main/java/org/aibe4/dodeul/domain/member/controller/ProfileImageApiController.java
+++ b/src/main/java/org/aibe4/dodeul/domain/member/controller/ProfileImageApiController.java
@@ -1,0 +1,42 @@
+package org.aibe4.dodeul.domain.member.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.aibe4.dodeul.domain.member.service.ProfileImageService;
+import org.aibe4.dodeul.global.response.CommonResponse;
+import org.aibe4.dodeul.global.response.enums.SuccessCode;
+import org.aibe4.dodeul.global.security.CustomUserDetails;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/mypage")
+public class ProfileImageApiController {
+
+    private final ProfileImageService profileImageService;
+
+    @PreAuthorize("hasRole('MENTOR')")
+    @PostMapping(value = "/mentor/profile-image", consumes = "multipart/form-data")
+    public CommonResponse<String> uploadMentorProfileImage(
+        @AuthenticationPrincipal CustomUserDetails user,
+        @RequestPart("file") MultipartFile file
+    ) {
+        String url = profileImageService.uploadMentorProfileImage(user.getMemberId(), file);
+        return CommonResponse.success(SuccessCode.UPDATE_SUCCESS, url, "멘토 프로필 이미지 업로드 성공");
+    }
+
+    @PreAuthorize("hasRole('MENTEE')")
+    @PostMapping(value = "/mentee/profile-image", consumes = "multipart/form-data")
+    public CommonResponse<String> uploadMenteeProfileImage(
+        @AuthenticationPrincipal CustomUserDetails user,
+        @RequestPart("file") MultipartFile file
+    ) {
+        String url = profileImageService.uploadMenteeProfileImage(user.getMemberId(), file);
+        return CommonResponse.success(SuccessCode.UPDATE_SUCCESS, url, "멘티 프로필 이미지 업로드 성공");
+    }
+}

--- a/src/main/java/org/aibe4/dodeul/domain/member/model/repository/MemberConsultingTagRepository.java
+++ b/src/main/java/org/aibe4/dodeul/domain/member/model/repository/MemberConsultingTagRepository.java
@@ -4,5 +4,5 @@ import org.aibe4.dodeul.domain.member.model.entity.MemberConsultingTag;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberConsultingTagRepository extends JpaRepository<MemberConsultingTag, Long> {
-    void deleteAllByMemberId(Long memberId);
+    void deleteAllByMember_Id(Long memberId);
 }

--- a/src/main/java/org/aibe4/dodeul/domain/member/service/ProfileImageService.java
+++ b/src/main/java/org/aibe4/dodeul/domain/member/service/ProfileImageService.java
@@ -1,0 +1,80 @@
+package org.aibe4.dodeul.domain.member.service;
+
+import lombok.RequiredArgsConstructor;
+import org.aibe4.dodeul.domain.member.model.entity.Member;
+import org.aibe4.dodeul.domain.member.model.entity.MenteeProfile;
+import org.aibe4.dodeul.domain.member.model.entity.MentorProfile;
+import org.aibe4.dodeul.domain.member.model.enums.Role;
+import org.aibe4.dodeul.domain.member.model.repository.MemberRepository;
+import org.aibe4.dodeul.domain.member.model.repository.MenteeProfileRepository;
+import org.aibe4.dodeul.domain.member.model.repository.MentorProfileRepository;
+import org.aibe4.dodeul.global.exception.BusinessException;
+import org.aibe4.dodeul.global.file.model.dto.response.FileUploadResponse;
+import org.aibe4.dodeul.global.file.service.FileService;
+import org.aibe4.dodeul.global.response.enums.ErrorCode;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ProfileImageService {
+
+    private final FileService fileService;
+    private final MemberRepository memberRepository;
+    private final MentorProfileRepository mentorProfileRepository;
+    private final MenteeProfileRepository menteeProfileRepository;
+
+    public String uploadMentorProfileImage(Long memberId, MultipartFile file) {
+        Member member = getMemberOrThrow(memberId);
+        if (member.getRole() != Role.MENTOR) {
+            throw new BusinessException(ErrorCode.ACCESS_DENIED);
+        }
+
+        MentorProfile profile = mentorProfileRepository.findById(memberId)
+            .orElseGet(() -> mentorProfileRepository.save(MentorProfile.create(member)));
+
+        FileUploadResponse upload =
+            fileService.upload(file, "profile/mentor");
+
+        profile.updateProfile(
+            upload.getFileUrl(),
+            profile.getIntro(),
+            profile.getJob(),
+            profile.getCareerYears(),
+            profile.isConsultationEnabled()
+        );
+
+        return upload.getFileUrl();
+    }
+
+    public String uploadMenteeProfileImage(Long memberId, MultipartFile file) {
+        Member member = getMemberOrThrow(memberId);
+        if (member.getRole() != Role.MENTEE) {
+            throw new BusinessException(ErrorCode.ACCESS_DENIED);
+        }
+
+        MenteeProfile profile = menteeProfileRepository.findById(memberId)
+            .orElseGet(() -> menteeProfileRepository.save(MenteeProfile.create(member)));
+
+        FileUploadResponse upload =
+            fileService.upload(file, "profile/mentee");
+
+        profile.updateProfile(
+            upload.getFileUrl(),
+            profile.getIntro(),
+            profile.getJob()
+        );
+
+        return upload.getFileUrl();
+    }
+
+    private Member getMemberOrThrow(Long memberId) {
+        return memberRepository.findById(memberId)
+            .orElseThrow(() -> new BusinessException(
+                ErrorCode.UNAUTHORIZED_ACCESS,
+                "인증 정보가 유효하지 않습니다."
+            ));
+    }
+}

--- a/src/main/resources/templates/common/fragments/header.html
+++ b/src/main/resources/templates/common/fragments/header.html
@@ -26,16 +26,17 @@
       <div sec:authorize="isAuthenticated()"
            style="display:flex; align-items:center; gap:12px;">
 
-        <!-- 프로필 아이콘 -->
-        <img th:src="@{/css/icons/usericon.svg}"
+        <!-- 프로필 아이콘: JS가 src를 교체할 수 있도록 id 부여 -->
+        <img id="headerProfileImg"
+             th:src="@{/css/icons/usericon.svg}"
              alt="profile"
-             style="width:32px; height:32px; border-radius:50%; background:#f2f2f2; padding:4px;"/>
+             style="width:32px; height:32px; border-radius:50%; background:#f2f2f2; padding:4px; object-fit:cover;"/>
 
-        <!-- 유저 이름 (현재는 email) -->
-        <span style="font-weight:600;"
-              sec:authentication="principal.nickname">
-          user
-        </span>
+        <!-- role을 JS가 읽도록 숨김 값으로 렌더 -->
+        <span id="headerUserRole" sec:authentication="principal.role" style="display:none;">ROLE</span>
+
+        <!-- 유저 이름 -->
+        <span style="font-weight:600;" sec:authentication="principal.nickname">user</span>
 
         <!-- 로그아웃 -->
         <form th:action="@{/logout}" method="post" style="margin:0;">
@@ -50,6 +51,46 @@
 
     </div>
   </div>
+
+  <!-- 헤더 자동 반영 스크립트 -->
+  <script sec:authorize="isAuthenticated()">
+    (async function () {
+      try {
+        const roleEl = document.getElementById('headerUserRole');
+        const imgEl = document.getElementById('headerProfileImg');
+        if (!roleEl || !imgEl) return;
+
+        const role = (roleEl.textContent || '').trim(); // "MENTOR" or "MENTEE"
+        let url = null;
+
+        if (role === 'MENTOR') url = '/api/mypage/mentor/profile';
+        else if (role === 'MENTEE') url = '/api/mypage/mentee/profile';
+        else return;
+
+        const res = await fetch(url, {
+          credentials: 'same-origin',
+          headers: {'accept': 'application/json'}
+        });
+
+        const json = await res.json().catch(() => null);
+        if (!res.ok) return;
+
+        const profileUrl = json?.data?.profileUrl;
+        if (!profileUrl) return;
+
+        // 캐시 방지
+        const cacheBusted = profileUrl + (profileUrl.includes('?') ? '&' : '?') + 't=' + Date.now();
+
+        imgEl.src = cacheBusted;
+        imgEl.style.padding = '0px';
+        imgEl.style.background = 'none';
+        imgEl.style.objectFit = 'cover';
+      } catch (e) {
+        console.debug('header profile image sync failed', e);
+      }
+    })();
+  </script>
+
 </header>
 
 </body>

--- a/src/main/resources/templates/mypage/mentee/dashboard.html
+++ b/src/main/resources/templates/mypage/mentee/dashboard.html
@@ -8,6 +8,13 @@
   <th:block layout:fragment="head">
     <title>DODEUL | 멘티 대시보드</title>
     <link rel="stylesheet" href="/css/mypage/dashboard.css">
+    <style>
+      #profileAvatar {
+        background-size: cover;
+        background-position: center;
+        background-repeat: no-repeat;
+      }
+    </style>
   </th:block>
 </head>
 
@@ -23,7 +30,7 @@
   <!-- 상단 프로필 카드 -->
   <section class="card-custom" style="margin-bottom:16px;">
     <div class="dashboard-profile">
-      <div class="dashboard-avatar-lg"></div>
+      <div class="dashboard-avatar-lg" id="profileAvatar"></div>
       <div style="flex:1;">
         <div class="fw-bold" id="menteeName" style="margin-bottom:4px;">-</div>
         <div class="text-small" id="menteeDesc">내 프로필 정보를 불러오는 중…</div>
@@ -32,12 +39,11 @@
     </div>
   </section>
 
-  <!-- 상담 현황 요약 (3칸 고정: 대기중/진행중/완료) -->
+  <!-- 상담 현황 요약 -->
   <section style="margin-bottom:16px;">
     <div class="fw-bold" style="margin-bottom:10px;">상담 현황 요약</div>
 
     <div class="dashboard-summary-grid">
-      <!-- 대기중(신청중) -->
       <div class="card-custom" style="margin:0; position:relative;">
         <div class="text-small">대기중 상담</div>
         <div class="dashboard-summary-value">
@@ -47,7 +53,6 @@
         <a class="text-small" style="position:absolute; right:16px; bottom:16px;" href="/mentee/sessions">상담 내역 보기 →</a>
       </div>
 
-      <!-- 진행중(승인됨=진행중) -->
       <div class="card-custom" style="margin:0; position:relative;">
         <div class="text-small">진행중 상담</div>
         <div class="dashboard-summary-value">
@@ -57,7 +62,6 @@
         <a class="text-small" style="position:absolute; right:16px; bottom:16px;" href="/mentee/sessions">상담 내역 보기 →</a>
       </div>
 
-      <!-- 완료 -->
       <div class="card-custom" style="margin:0; position:relative;">
         <div class="text-small">완료된 상담</div>
         <div class="dashboard-summary-value">
@@ -79,7 +83,7 @@
     </div>
   </section>
 
-  <!-- 최근 상담 내역(= 완료된 상담 최근 3개로 바꿀 예정) -->
+  <!-- 최근 상담 내역 -->
   <section style="margin-bottom:16px;">
     <div class="fw-bold" style="margin-bottom:10px;">최근 상담 내역</div>
     <div class="card-custom dashboard-list" id="recentList" style="margin:0;">
@@ -104,9 +108,6 @@
 
 <th:block layout:fragment="script">
   <script>
-    // =========================
-    // Team standard: CommonResponse + unified fetch
-    // =========================
     async function apiRequest(url, options = {}) {
       const res = await fetch(url, {
         credentials: 'same-origin',
@@ -115,7 +116,6 @@
       });
 
       const json = await res.json().catch(() => null);
-
       const code = json?.code ?? res.status;
       const message = json?.message ?? `요청 실패(${res.status})`;
 
@@ -129,14 +129,12 @@
         location.href = '/';
         throw new Error('FORBIDDEN');
       }
-
       if (!res.ok || (typeof code === 'number' && code >= 400)) {
         const err = new Error(message);
         err.code = code;
         err.payload = json;
         throw err;
       }
-
       return json;
     }
 
@@ -147,6 +145,18 @@
         .replaceAll('>', '&gt;')
         .replaceAll('"', '&quot;')
         .replaceAll("'", "&#039;");
+    }
+
+    function setAvatar(url) {
+      const el = document.getElementById('profileAvatar');
+      if (!el) return;
+
+      if (url) {
+        const cacheBusted = url + (url.includes('?') ? '&' : '?') + 't=' + Date.now();
+        el.style.backgroundImage = `url(${cacheBusted})`;
+      } else {
+        el.style.backgroundImage = 'none';
+      }
     }
 
     function formatDateTime(v) {
@@ -186,49 +196,23 @@
       const err = document.getElementById('dashboardError');
 
       try {
-        const json = await apiRequest('/api/mypage/dashboard');
-        const data = json.data || {};
-
-        document.getElementById('menteeName').textContent = data.nickname ? `${data.nickname} 멘티` : '멘티';
-
-        // (선택) 아래 필드는 dashboard 응답에 없을 수 있으니 fallback 유지
-        const desiredJob = data.desiredJobName ?? '-';
-        const interests = (data.interestConsultings && data.interestConsultings.length)
-          ? data.interestConsultings.join(', ')
-          : '-';
-        document.getElementById('menteeDesc').textContent = `${desiredJob} / ${interests}`;
+        const dashJson = await apiRequest('/api/mypage/dashboard');
+        const dash = dashJson.data || {};
 
         document.getElementById('dashboardSubtitle').textContent = '멘티님의 상담 현황을 확인해보세요.';
 
-        // summary: scheduled(=WAITING), ongoing(=MATCHED), completed(=COMPLETED)
-        document.getElementById('sumScheduled').textContent = data.summary?.scheduled ?? '-';
-        document.getElementById('sumOngoing').textContent = data.summary?.ongoing ?? '-';
-        document.getElementById('sumCompleted').textContent = data.summary?.completed ?? '-';
+        document.getElementById('sumScheduled').textContent = dash.summary?.scheduled ?? '-';
+        document.getElementById('sumOngoing').textContent = dash.summary?.ongoing ?? '-';
+        document.getElementById('sumCompleted').textContent = dash.summary?.completed ?? '-';
 
-        const upcoming = data.upcomingSessions || [];
+        const upcoming = dash.upcomingSessions || [];
+        renderRows(document.getElementById('ongoingList'), upcoming.slice(0, 2), '진행중인 상담이 없습니다.', '상담 내역', () => `/mentee/sessions`);
 
-        renderRows(
-          document.getElementById('ongoingList'),
-          upcoming.slice(0, 2),
-          '진행중인 상담이 없습니다.',
-          '상담 내역',
-          () => `/mentee/sessions`
-        );
+        const completedRecentSessions = dash.completedRecentSessions || [];
+        renderRows(document.getElementById('recentList'), completedRecentSessions, '최근 완료된 상담 내역이 없습니다.', '상담 내역 조회', () => `/mentee/sessions`);
 
-        const completedRecentSessions = data.completedRecentSessions || [];
-
-        renderRows(
-          document.getElementById('recentList'),
-          completedRecentSessions,
-          '최근 완료된 상담 내역이 없습니다.',
-          '상담 내역 조회',
-          () => `/mentee/sessions`
-        );
-
-        // 최근 스크랩 글: 현재는 mock 1개 (추후 API 필드로 교체)
         const scrapEl = document.getElementById('scrapBox');
         const mockScrap = {title: '멘토 추천 기능 정리 글', href: '/board/posts'};
-
         scrapEl.innerHTML = `
           <div class="dashboard-row">
             <div>
@@ -240,6 +224,19 @@
             </div>
           </div>
         `;
+
+        const profileRes = await fetch('/api/mypage/mentee/profile', {credentials: 'same-origin'});
+        const profileJson = await profileRes.json().catch(() => null);
+        if (profileRes.ok) {
+          const p = profileJson?.data || {};
+          document.getElementById('menteeName').textContent = p.nickname ? `${p.nickname} 멘티` : '멘티';
+
+          const job = p.job ?? '-';
+          const fields = (p.consultingTags && p.consultingTags.length) ? p.consultingTags.join(', ') : '-';
+          document.getElementById('menteeDesc').textContent = `${job} / ${fields}`;
+
+          setAvatar(p.profileUrl);
+        }
       } catch (e) {
         console.error(e);
         err.textContent = e?.message ?? '서버와 통신할 수 없습니다.';

--- a/src/main/resources/templates/mypage/mentee/profile-edit.html
+++ b/src/main/resources/templates/mypage/mentee/profile-edit.html
@@ -8,6 +8,23 @@
   <th:block layout:fragment="head">
     <title>DODEUL | 멘티 프로필 수정</title>
     <link rel="stylesheet" href="/css/mypage/dashboard.css">
+    <style>
+      .profile-avatar {
+        position: relative;
+        cursor: default;
+      }
+
+      .avatar-actions {
+        display: flex;
+        gap: 10px;
+        align-items: center;
+        margin-top: 8px;
+      }
+
+      .upload-status {
+        font-size: 12px;
+      }
+    </style>
   </th:block>
 </head>
 
@@ -22,11 +39,25 @@
   <!-- 상단 프로필 카드 -->
   <section class="card-custom" style="margin-bottom:16px;">
     <div class="dashboard-profile">
-      <div class="dashboard-avatar-lg"></div>
+      <div class="dashboard-avatar-lg profile-avatar" id="profileAvatar"></div>
+
       <div style="flex:1;">
         <div class="fw-bold" id="menteeName" style="margin-bottom:4px;">-</div>
         <div class="text-small" id="menteeMeta">희망 직무 / 관심 상담 분야</div>
+
+        <!-- 이미지 업로드 UI -->
+        <div class="avatar-actions">
+          <input
+            type="file"
+            id="profileImageInput"
+            accept="image/png,image/jpeg"
+            style="display:none"
+          />
+          <button id="changeImageBtn" class="btn-outline-custom" type="button">이미지 변경</button>
+          <span id="uploadStatus" class="upload-status text-small"></span>
+        </div>
       </div>
+
       <a class="btn-outline-custom" href="/mentee/profile">조회 화면</a>
     </div>
   </section>
@@ -106,6 +137,62 @@
         .filter(Boolean);
     }
 
+    function setAvatar(url) {
+      const avatar = document.getElementById('profileAvatar');
+      if (!avatar) return;
+
+      if (url) {
+        avatar.style.backgroundImage = `url(${url})`;
+        avatar.style.backgroundSize = 'cover';
+        avatar.style.backgroundPosition = 'center';
+      } else {
+        avatar.style.backgroundImage = 'none';
+      }
+    }
+
+    // 이미지 업로드
+    document.getElementById('changeImageBtn').addEventListener('click', () => {
+      document.getElementById('profileImageInput').click();
+    });
+
+    document.getElementById('profileImageInput').addEventListener('change', async (e) => {
+      const status = document.getElementById('uploadStatus');
+      status.textContent = '';
+
+      const file = e.target.files && e.target.files[0];
+      if (!file) return;
+
+      try {
+        status.textContent = '업로드 중...';
+
+        const form = new FormData();
+        form.append('file', file);
+
+        const res = await fetch('/api/mypage/mentee/profile-image', {
+          method: 'POST',
+          body: form,
+          credentials: 'same-origin'
+        });
+
+        const json = await res.json().catch(() => null);
+        if (!res.ok) {
+          status.textContent = json?.message || '이미지 업로드 실패';
+          return;
+        }
+
+        const url = json?.data;
+        setAvatar(url);
+        status.textContent = '업로드 완료';
+
+      } catch (err) {
+        console.error(err);
+        status.textContent = '서버 오류';
+      } finally {
+        // 같은 파일 재선택 가능하도록 초기화
+        e.target.value = '';
+      }
+    });
+
     // 초기값 로딩
     (async function () {
       const err = document.getElementById('profileError');
@@ -125,6 +212,8 @@
           ? data.consultingTags.join(', ')
           : '-';
         document.getElementById('menteeMeta').textContent = `희망 직무: ${desiredJob} · 관심 상담 분야: ${interests}`;
+
+        setAvatar(data.profileUrl);
 
         document.getElementById('desiredJobInput').value = data.job ?? '';
         document.getElementById('bioInput').value = data.intro ?? '';

--- a/src/main/resources/templates/mypage/mentee/profile.html
+++ b/src/main/resources/templates/mypage/mentee/profile.html
@@ -8,6 +8,13 @@
   <th:block layout:fragment="head">
     <title>DODEUL | 멘티 프로필</title>
     <link rel="stylesheet" href="/css/mypage/dashboard.css">
+    <style>
+      #profileAvatar {
+        background-size: cover;
+        background-position: center;
+        background-repeat: no-repeat;
+      }
+    </style>
   </th:block>
 </head>
 
@@ -18,10 +25,10 @@
     <p class="text-small" style="margin-bottom:16px;">멘티 프로필 정보를 확인할 수 있습니다.</p>
   </div>
 
-  <!-- 상단 프로필 카드 -->
   <section class="card-custom" style="margin-bottom:16px;">
     <div class="dashboard-profile">
-      <div class="dashboard-avatar-lg"></div>
+      <div class="dashboard-avatar-lg" id="profileAvatar"></div>
+
       <div style="flex:1;">
         <div class="fw-bold" id="menteeName" style="margin-bottom:4px;">-</div>
         <div class="text-small" id="menteeMeta">희망 직무 / 관심 상담 분야</div>
@@ -29,34 +36,24 @@
     </div>
   </section>
 
-  <!-- 희망 직무 -->
   <section class="card-custom" style="margin-bottom:16px;">
     <div class="fw-bold" style="margin-bottom:10px;">희망 직무</div>
     <div id="desiredJob" class="text-small">불러오는 중…</div>
   </section>
 
-  <!-- 자기소개 -->
   <section class="card-custom" style="margin-bottom:16px;">
     <div class="fw-bold" style="margin-bottom:10px;">자기소개</div>
-    <div id="menteeBio" class="text-small" style="white-space:pre-line;">
-      불러오는 중…
-    </div>
+    <div id="menteeBio" class="text-small" style="white-space:pre-line;">불러오는 중…</div>
   </section>
 
-  <!-- 기술 스택 -->
   <section class="card-custom" style="margin-bottom:16px;">
     <div class="fw-bold" style="margin-bottom:10px;">기술 스택</div>
-    <div id="menteeSkills">
-      <span class="text-small">불러오는 중…</span>
-    </div>
+    <div id="menteeSkills"><span class="text-small">불러오는 중…</span></div>
   </section>
 
-  <!-- 상담 희망 분야 -->
   <section class="card-custom" style="margin-bottom:16px;">
     <div class="fw-bold" style="margin-bottom:10px;">상담 희망 분야</div>
-    <div id="menteeConsultings">
-      <span class="text-small">불러오는 중…</span>
-    </div>
+    <div id="menteeConsultings"><span class="text-small">불러오는 중…</span></div>
   </section>
 
   <div style="display:flex; justify-content:flex-end; margin-top:16px;">
@@ -85,40 +82,47 @@
       root.innerHTML = arr.map(t => `<span class="tag tag--read-only">${escapeHtml(t)}</span>`).join('');
     }
 
+    function setAvatar(url) {
+      const el = document.getElementById('profileAvatar');
+      if (!el) return;
+
+      if (url) {
+        const cacheBusted = url + (url.includes('?') ? '&' : '?') + 't=' + Date.now();
+        el.style.backgroundImage = `url(${cacheBusted})`;
+      } else {
+        el.style.backgroundImage = 'none';
+      }
+    }
+
     (async function () {
       const err = document.getElementById('profileError');
 
       try {
-        const res = await fetch('/api/mypage/dashboard', {credentials: 'same-origin'});
-        const json = await res.json();
+        const res = await fetch('/api/mypage/mentee/profile', {credentials: 'same-origin'});
+        const json = await res.json().catch(() => null);
         if (!res.ok) {
           err.textContent = json?.message || '프로필 정보를 불러오지 못했습니다.';
           return;
         }
 
-        const data = json.data || {};
+        const data = json?.data || {};
         document.getElementById('menteeName').textContent = data.nickname ? `${data.nickname} 멘티` : '멘티';
 
-        const desiredJob = data.desiredJobName ?? '-';
-        const interests = (data.interestConsultings && data.interestConsultings.length)
-          ? data.interestConsultings.join(', ')
+        const desiredJob = data.job ?? '-';
+        const interests = (data.consultingTags && data.consultingTags.length)
+          ? data.consultingTags.join(', ')
           : '-';
 
         document.getElementById('menteeMeta').textContent = `희망 직무: ${desiredJob} · 관심 상담 분야: ${interests}`;
         document.getElementById('desiredJob').textContent = desiredJob;
 
         document.getElementById('menteeBio').textContent =
-          data.bio ?? '자기소개가 아직 등록되지 않았습니다.';
+          data.intro ?? '자기소개가 아직 등록되지 않았습니다.';
 
-        renderTags(
-          document.getElementById('menteeSkills'),
-          data.skillTags ?? ['Java', 'Spring'] // 임시
-        );
+        renderTags(document.getElementById('menteeSkills'), data.skillTags ?? []);
+        renderTags(document.getElementById('menteeConsultings'), data.consultingTags ?? []);
 
-        renderTags(
-          document.getElementById('menteeConsultings'),
-          data.interestConsultings ?? ['이력서', '면접'] // 임시
-        );
+        setAvatar(data.profileUrl);
 
       } catch (e) {
         err.textContent = '서버와 통신할 수 없습니다.';

--- a/src/main/resources/templates/mypage/mentee/sessions.html
+++ b/src/main/resources/templates/mypage/mentee/sessions.html
@@ -112,8 +112,7 @@
     }
 
     function roomHref(matchingId) {
-      // TODO: 상담방 라우트 확정되면 교체
-      return `/consulting-room/${matchingId}`;
+      return `/consultations/room/${matchingId}`;
     }
 
     function applicationHref(matchingId) {

--- a/src/main/resources/templates/mypage/mentor/dashboard.html
+++ b/src/main/resources/templates/mypage/mentor/dashboard.html
@@ -8,6 +8,13 @@
   <th:block layout:fragment="head">
     <title>DODEUL | 멘토 대시보드</title>
     <link rel="stylesheet" href="/css/mypage/dashboard.css">
+    <style>
+      #profileAvatar {
+        background-size: cover;
+        background-position: center;
+        background-repeat: no-repeat;
+      }
+    </style>
   </th:block>
 </head>
 
@@ -23,7 +30,7 @@
   <!-- 상단 프로필 카드 -->
   <section class="card-custom" style="margin-bottom:16px;">
     <div class="dashboard-profile">
-      <div class="dashboard-avatar-lg"></div>
+      <div class="dashboard-avatar-lg" id="profileAvatar"></div>
       <div style="flex:1;">
         <div class="fw-bold" id="mentorName" style="margin-bottom:4px;">-</div>
         <div class="text-small" id="mentorDesc">내 프로필 정보를 불러오는 중…</div>
@@ -32,12 +39,11 @@
     </div>
   </section>
 
-  <!-- 상담 현황 요약 (3칸 고정: 받은 신청/진행중/완료) -->
+  <!-- 상담 현황 요약 -->
   <section style="margin-bottom:16px;">
     <div class="fw-bold" style="margin-bottom:10px;">상담 현황 요약</div>
 
     <div class="dashboard-summary-grid">
-      <!-- 받은 신청(대기중) -->
       <div class="card-custom" style="margin:0; position:relative;">
         <div class="text-small">받은 상담 신청</div>
         <div class="dashboard-summary-value">
@@ -47,7 +53,6 @@
         <a class="text-small" style="position:absolute; right:16px; bottom:16px;" href="/mentor/sessions">상담 내역 보기 →</a>
       </div>
 
-      <!-- 진행중(승인됨) -->
       <div class="card-custom" style="margin:0; position:relative;">
         <div class="text-small">진행중 상담</div>
         <div class="dashboard-summary-value">
@@ -57,7 +62,6 @@
         <a class="text-small" style="position:absolute; right:16px; bottom:16px;" href="/mentor/sessions">상담 내역 보기 →</a>
       </div>
 
-      <!-- 완료 -->
       <div class="card-custom" style="margin:0; position:relative;">
         <div class="text-small">완료된 상담</div>
         <div class="dashboard-summary-value">
@@ -79,7 +83,7 @@
     </div>
   </section>
 
-  <!-- 최근 상담 내역(= 완료된 상담 최근 3개로 바꿀 예정) -->
+  <!-- 최근 상담 내역 -->
   <section style="margin-bottom:16px;">
     <div class="fw-bold" style="margin-bottom:10px;">최근 상담 내역</div>
     <div class="card-custom dashboard-list" id="recentList" style="margin:0;">
@@ -112,7 +116,6 @@
       });
 
       const json = await res.json().catch(() => null);
-
       const code = json?.code ?? res.status;
       const message = json?.message ?? `요청 실패(${res.status})`;
 
@@ -126,14 +129,12 @@
         location.href = '/';
         throw new Error('FORBIDDEN');
       }
-
       if (!res.ok || (typeof code === 'number' && code >= 400)) {
         const err = new Error(message);
         err.code = code;
         err.payload = json;
         throw err;
       }
-
       return json;
     }
 
@@ -144,6 +145,18 @@
         .replaceAll('>', '&gt;')
         .replaceAll('"', '&quot;')
         .replaceAll("'", "&#039;");
+    }
+
+    function setAvatar(url) {
+      const el = document.getElementById('profileAvatar');
+      if (!el) return;
+
+      if (url) {
+        const cacheBusted = url + (url.includes('?') ? '&' : '?') + 't=' + Date.now();
+        el.style.backgroundImage = `url(${cacheBusted})`;
+      } else {
+        el.style.backgroundImage = 'none';
+      }
     }
 
     function formatDateTime(v) {
@@ -183,47 +196,24 @@
       const err = document.getElementById('dashboardError');
 
       try {
-        const json = await apiRequest('/api/mypage/dashboard');
-        const data = json.data || {};
+        // 1) 대시보드 데이터
+        const dashJson = await apiRequest('/api/mypage/dashboard');
+        const dash = dashJson.data || {};
 
-        document.getElementById('mentorName').textContent = data.nickname ? `${data.nickname} 멘토` : '멘토';
-
-        const job = data.jobName ?? '-';
-        const interests = (data.interestConsultings && data.interestConsultings.length)
-          ? data.interestConsultings.join(', ')
-          : '-';
-
-        document.getElementById('mentorDesc').textContent = `${job} / ${interests}`;
         document.getElementById('dashboardSubtitle').textContent = '멘토님의 상담 현황을 확인해보세요.';
 
-        // summary: scheduled(=WAITING), ongoing(=MATCHED), completed(=COMPLETED)
-        document.getElementById('sumScheduled').textContent = data.summary?.scheduled ?? '-';
-        document.getElementById('sumOngoing').textContent = data.summary?.ongoing ?? '-';
-        document.getElementById('sumCompleted').textContent = data.summary?.completed ?? '-';
+        document.getElementById('sumScheduled').textContent = dash.summary?.scheduled ?? '-';
+        document.getElementById('sumOngoing').textContent = dash.summary?.ongoing ?? '-';
+        document.getElementById('sumCompleted').textContent = dash.summary?.completed ?? '-';
 
-        const upcoming = data.upcomingSessions || [];
+        const upcoming = dash.upcomingSessions || [];
+        renderRows(document.getElementById('ongoingList'), upcoming.slice(0, 2), '진행중인 상담이 없습니다.', '상담 내역', () => `/mentor/sessions`);
 
-        renderRows(
-          document.getElementById('ongoingList'),
-          upcoming.slice(0, 2),
-          '진행중인 상담이 없습니다.',
-          '상담 내역',
-          () => `/mentor/sessions`
-        );
-
-        const completedRecentSessions = data.completedRecentSessions || [];
-
-        renderRows(
-          document.getElementById('recentList'),
-          completedRecentSessions,
-          '최근 완료된 상담 내역이 없습니다.',
-          '상담 내역 조회',
-          () => `/mentor/sessions`
-        );
+        const completedRecentSessions = dash.completedRecentSessions || [];
+        renderRows(document.getElementById('recentList'), completedRecentSessions, '최근 완료된 상담 내역이 없습니다.', '상담 내역 조회', () => `/mentor/sessions`);
 
         const scrapEl = document.getElementById('scrapBox');
         const mockScrap = {title: '멘토링 질문 템플릿 공유합니다', href: '/board/posts'};
-
         scrapEl.innerHTML = `
           <div class="dashboard-row">
             <div>
@@ -235,6 +225,19 @@
             </div>
           </div>
         `;
+
+        const profileRes = await fetch('/api/mypage/mentor/profile', {credentials: 'same-origin'});
+        const profileJson = await profileRes.json().catch(() => null);
+        if (profileRes.ok) {
+          const p = profileJson?.data || {};
+          document.getElementById('mentorName').textContent = p.nickname ? `${p.nickname} 멘토` : '멘토';
+
+          const job = p.job ?? '-';
+          const fields = (p.consultingTags && p.consultingTags.length) ? p.consultingTags.join(', ') : '-';
+          document.getElementById('mentorDesc').textContent = `${job} / ${fields}`;
+
+          setAvatar(p.profileUrl);
+        }
       } catch (e) {
         console.error(e);
         err.textContent = e?.message ?? '서버와 통신할 수 없습니다.';

--- a/src/main/resources/templates/mypage/mentor/profile-edit.html
+++ b/src/main/resources/templates/mypage/mentor/profile-edit.html
@@ -8,6 +8,23 @@
   <th:block layout:fragment="head">
     <title>DODEUL | 멘토 프로필 수정</title>
     <link rel="stylesheet" href="/css/mypage/dashboard.css">
+    <style>
+      .profile-avatar {
+        position: relative;
+        cursor: default;
+      }
+
+      .avatar-actions {
+        display: flex;
+        gap: 10px;
+        align-items: center;
+        margin-top: 8px;
+      }
+
+      .upload-status {
+        font-size: 12px;
+      }
+    </style>
   </th:block>
 </head>
 
@@ -22,18 +39,37 @@
   <!-- 상단 프로필 카드-->
   <section class="card-custom" style="margin-bottom:16px;">
     <div class="dashboard-profile">
-      <div class="dashboard-avatar-lg"></div>
+      <div class="dashboard-avatar-lg profile-avatar" id="profileAvatar"></div>
+
       <div style="flex:1;">
         <div class="fw-bold" id="mentorName" style="margin-bottom:4px;">-</div>
         <div class="text-small" id="mentorMeta">직무 / 상담 가능 분야</div>
+
+        <!-- 이미지 업로드 UI -->
+        <div class="avatar-actions">
+          <input
+            type="file"
+            id="profileImageInput"
+            accept="image/png,image/jpeg"
+            style="display:none"
+          />
+          <button id="changeImageBtn" class="btn-outline-custom" type="button">이미지 변경</button>
+          <span id="uploadStatus" class="upload-status text-small"></span>
+        </div>
       </div>
+
       <a class="btn-outline-custom" href="/mentor/profile">조회 화면</a>
     </div>
   </section>
 
   <!-- 편집 폼 -->
   <form class="card-custom" style="margin-bottom:16px;" onsubmit="return false;">
-    <div class="fw-bold" style="margin-bottom:10px;">자기소개</div>
+
+    <div class="fw-bold" style="margin-bottom:10px;">직무</div>
+    <input id="jobInput" class="form-control-custom" type="text"
+           placeholder="예: 백엔드 개발자">
+
+    <div class="fw-bold" style="margin:16px 0 10px;">자기소개</div>
     <textarea id="bioInput" class="form-control-custom" rows="5"
               placeholder="자기소개를 입력해 주세요."></textarea>
 
@@ -102,6 +138,61 @@
         .filter(Boolean);
     }
 
+    function setAvatar(url) {
+      const avatar = document.getElementById('profileAvatar');
+      if (!avatar) return;
+
+      if (url) {
+        avatar.style.backgroundImage = `url(${url})`;
+        avatar.style.backgroundSize = 'cover';
+        avatar.style.backgroundPosition = 'center';
+      } else {
+        avatar.style.backgroundImage = 'none';
+      }
+    }
+
+    // 이미지 업로드
+    document.getElementById('changeImageBtn').addEventListener('click', () => {
+      document.getElementById('profileImageInput').click();
+    });
+
+    document.getElementById('profileImageInput').addEventListener('change', async (e) => {
+      const status = document.getElementById('uploadStatus');
+      status.textContent = '';
+
+      const file = e.target.files && e.target.files[0];
+      if (!file) return;
+
+      try {
+        status.textContent = '업로드 중...';
+
+        const form = new FormData();
+        form.append('file', file);
+
+        const res = await fetch('/api/mypage/mentor/profile-image', {
+          method: 'POST',
+          body: form,
+          credentials: 'same-origin'
+        });
+
+        const json = await res.json().catch(() => null);
+        if (!res.ok) {
+          status.textContent = json?.message || '이미지 업로드 실패';
+          return;
+        }
+
+        const url = json?.data;
+        setAvatar(url);
+        status.textContent = '업로드 완료';
+
+      } catch (err) {
+        console.error(err);
+        status.textContent = '서버 오류';
+      } finally {
+        e.target.value = '';
+      }
+    });
+
     // 초기값 로딩
     (async function () {
       const err = document.getElementById('profileError');
@@ -122,6 +213,9 @@
           : '-';
         document.getElementById('mentorMeta').textContent = `${job} / ${fields}`;
 
+        setAvatar(data.profileUrl);
+
+        document.getElementById('jobInput').value = data.job ?? '';
         document.getElementById('bioInput').value = data.intro ?? '';
         document.getElementById('skillsInput').value =
           (data.skillTags && data.skillTags.length) ? data.skillTags.join(', ') : '';
@@ -140,6 +234,7 @@
       err.textContent = '';
 
       const payload = {
+        job: document.getElementById('jobInput').value.trim(),
         intro: document.getElementById('bioInput').value.trim(),
         skillTags: toListByComma(document.getElementById('skillsInput').value),
         consultingTags: toListByComma(document.getElementById('consultingsInput').value),

--- a/src/main/resources/templates/mypage/mentor/profile.html
+++ b/src/main/resources/templates/mypage/mentor/profile.html
@@ -8,6 +8,14 @@
   <th:block layout:fragment="head">
     <title>DODEUL | 멘토 프로필</title>
     <link rel="stylesheet" href="/css/mypage/dashboard.css">
+    <style>
+      /* 혹시 기본 CSS가 background를 안 보이게 할 수 있어서 안전하게 보정 */
+      #profileAvatar {
+        background-size: cover;
+        background-position: center;
+        background-repeat: no-repeat;
+      }
+    </style>
   </th:block>
 </head>
 
@@ -21,18 +29,11 @@
   <!-- 상단 프로필 카드 -->
   <section class="card-custom" style="margin-bottom:16px;">
     <div class="dashboard-profile">
-      <div class="dashboard-avatar-lg"></div>
+      <div class="dashboard-avatar-lg" id="profileAvatar"></div>
+
       <div style="flex:1;">
         <div class="fw-bold" id="mentorName" style="margin-bottom:4px;">-</div>
         <div class="text-small" id="mentorMeta">직무 / 상담 가능 분야</div>
-      </div>
-
-      <div style="display:flex; gap:10px; align-items:center;">
-        <div class="text-small" style="text-align:right;">
-          <div class="fw-medium">예약하기</div>
-          <div>이 멘토에게 상담을 신청할 수 있습니다.</div>
-        </div>
-        <a class="btn-primary-custom" href="/matchings/new" id="reserveBtn">예약하기</a>
       </div>
     </div>
   </section>
@@ -40,31 +41,25 @@
   <!-- 자기소개 -->
   <section class="card-custom" style="margin-bottom:16px;">
     <div class="fw-bold" style="margin-bottom:10px;">자기소개</div>
-    <div id="mentorBio" class="text-small" style="white-space:pre-line;">
-      불러오는 중…
-    </div>
+    <div id="mentorBio" class="text-small" style="white-space:pre-line;">불러오는 중…</div>
   </section>
 
   <!-- 기술 스택 -->
   <section class="card-custom" style="margin-bottom:16px;">
     <div class="fw-bold" style="margin-bottom:10px;">기술 스택</div>
-    <div id="mentorSkills">
-      <span class="text-small">불러오는 중…</span>
-    </div>
+    <div id="mentorSkills"><span class="text-small">불러오는 중…</span></div>
   </section>
 
   <!-- 상담 가능 분야 -->
   <section class="card-custom" style="margin-bottom:16px;">
     <div class="fw-bold" style="margin-bottom:10px;">상담 가능 분야</div>
-    <div id="mentorConsultings">
-      <span class="text-small">불러오는 중…</span>
-    </div>
+    <div id="mentorConsultings"><span class="text-small">불러오는 중…</span></div>
   </section>
 
   <div style="display:flex; justify-content:flex-end; margin-top:16px;">
     <a class="btn-outline-custom" href="/mentor/profile/edit">수정</a>
   </div>
-  
+
   <p id="profileError" style="color:#d33; margin-top:12px;"></p>
 </div>
 
@@ -87,39 +82,45 @@
       root.innerHTML = arr.map(t => `<span class="tag tag--read-only">${escapeHtml(t)}</span>`).join('');
     }
 
+    function setAvatar(url) {
+      const avatar = document.getElementById('profileAvatar');
+      if (!avatar) return;
+
+      if (url) {
+        // ✅ 캐시 때문에 안 바뀌는 현상 방지용 쿼리스트링
+        const cacheBusted = url + (url.includes('?') ? '&' : '?') + 't=' + Date.now();
+        avatar.style.backgroundImage = `url(${cacheBusted})`;
+      } else {
+        avatar.style.backgroundImage = 'none';
+      }
+    }
+
     (async function () {
       const err = document.getElementById('profileError');
 
       try {
-        // 임시로 dashboard API 재사용 (추후 /api/mypage/profile 같은 별도 API로 교체 추천)
-        const res = await fetch('/api/mypage/dashboard', {credentials: 'same-origin'});
-        const json = await res.json();
+        const res = await fetch('/api/mypage/mentor/profile', {credentials: 'same-origin'});
+        const json = await res.json().catch(() => null);
         if (!res.ok) {
           err.textContent = json?.message || '프로필 정보를 불러오지 못했습니다.';
           return;
         }
 
-        const data = json.data || {};
+        const data = json?.data || {};
         document.getElementById('mentorName').textContent = data.nickname ? `${data.nickname} 멘토` : '멘토';
 
-        // TODO: API에 mentor profile 필드 생기면 교체
-        const job = data.jobName ?? '-';
-        const consultings = (data.consultingFields && data.consultingFields.length) ? data.consultingFields : [];
+        const job = data.job ?? '-';
+        const consultings = (data.consultingTags && data.consultingTags.length) ? data.consultingTags : [];
         document.getElementById('mentorMeta').textContent =
           consultings.length ? `${job} / ${consultings.join(', ')}` : `${job} / -`;
 
         document.getElementById('mentorBio').textContent =
-          data.bio ?? '자기소개가 아직 등록되지 않았습니다.';
+          data.intro ?? '자기소개가 아직 등록되지 않았습니다.';
 
-        renderTags(
-          document.getElementById('mentorSkills'),
-          data.skillTags ?? ['Spring', 'JPA', 'MySQL'] // 임시
-        );
+        renderTags(document.getElementById('mentorSkills'), data.skillTags ?? []);
+        renderTags(document.getElementById('mentorConsultings'), data.consultingTags ?? []);
 
-        renderTags(
-          document.getElementById('mentorConsultings'),
-          data.consultingFields ?? ['이력서', '면접', '커리어'] // 임시
-        );
+        setAvatar(data.profileUrl);
 
       } catch (e) {
         err.textContent = '서버와 통신할 수 없습니다.';


### PR DESCRIPTION
## 관련 이슈
- closed: #182 

## 작업 내용
- 멘토 / 멘티 프로필 수정 화면 구현
- 기존 프로필 정보 조회 및 수정 가능하도록 처리
- Supabase Storage 기반 프로필 이미지 업로드 기능 추가
- 업로드된 이미지 URL을 프로필 정보에 저장 및 조회 화면에 반영
- 프로필 변경 사항이 마이페이지(대시보드/프로필) 및 헤더 영역에 자동 반영되도록 연동

## 체크 리스트
- [x] PR 제목 규칙을 준수했습니다
- [x] 관련 이슈를 연결했습니다 (#182)
- [x] 본문 내용을 명확하게 작성했습니다
- [x] 정상 작동을 로컬 환경에서 검증했습니다
- [ ] 
## 리뷰어에게
- 프로필 수정 / 이미지 업로드 기능 구현 과정에서
SkillTag 엔티티의 PK 컬럼명과 실제 DB 스키마 간 불일치로 인해
member_skill_tags 저장 시 FK제약 오류가 지속적으로 발생했습니다.
기존 구조를 유지한 채로 해결을 시도했는데, 구조적으로 해결이 어려워서 해결을 위해 
  @Column(name = "skill_tag_id") 부분을
 @Column(name = "id") 와 같이 수정했습니다.
 게시글 태그 등 다른 도메인에서도 영향을 받을 수 있는 변경이라서
 다른 기능에 문제가 없을지 의논드리고 싶습니다.

## 연관 이슈
- #