### PR TITLE
[FEAT] 게시글 스크랩 + 공개 게시판 UI/UX 개선 및 기능 고도화

### DIFF
--- a/src/main/java/org/aibe4/dodeul/domain/board/controller/BoardPostScrapApiController.java
+++ b/src/main/java/org/aibe4/dodeul/domain/board/controller/BoardPostScrapApiController.java
@@ -1,0 +1,55 @@
+// src/main/java/org/aibe4/dodeul/domain/board/controller/BoardPostScrapApiController.java
+package org.aibe4.dodeul.domain.board.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.aibe4.dodeul.domain.board.model.dto.response.BoardPostScrapStatusResponse;
+import org.aibe4.dodeul.domain.board.model.dto.response.BoardPostScrapToggleResponse;
+import org.aibe4.dodeul.domain.board.model.dto.response.MyScrapListResponse;
+import org.aibe4.dodeul.domain.board.service.BoardPostScrapService;
+import org.aibe4.dodeul.global.security.CustomUserDetails;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class BoardPostScrapApiController {
+
+    private final BoardPostScrapService boardPostScrapService;
+
+    @PostMapping("/board/posts/{postId}/scrap")
+    public BoardPostScrapToggleResponse toggle(
+        @AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long postId) {
+        Long memberId = userDetails == null ? null : userDetails.getMemberId();
+        if (memberId == null) {
+            throw new IllegalStateException("로그인이 필요합니다.");
+        }
+        return boardPostScrapService.toggle(memberId, postId);
+    }
+
+    @GetMapping("/board/posts/{postId}/scrap")
+    public BoardPostScrapStatusResponse status(
+        @AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long postId) {
+        Long memberId = userDetails == null ? null : userDetails.getMemberId();
+        return boardPostScrapService.getStatus(memberId, postId);
+    }
+
+    @DeleteMapping("/board/posts/{postId}/scrap")
+    public BoardPostScrapToggleResponse delete(
+        @AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long postId) {
+        Long memberId = userDetails == null ? null : userDetails.getMemberId();
+        if (memberId == null) {
+            throw new IllegalStateException("로그인이 필요합니다.");
+        }
+        return boardPostScrapService.delete(memberId, postId);
+    }
+
+    @GetMapping("/mypage/scraps")
+    public MyScrapListResponse myScraps(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long memberId = userDetails == null ? null : userDetails.getMemberId();
+        if (memberId == null) {
+            throw new IllegalStateException("로그인이 필요합니다.");
+        }
+        return boardPostScrapService.getMyScraps(memberId);
+    }
+}

--- a/src/main/java/org/aibe4/dodeul/domain/board/model/dto/response/BoardPostDetailResponse.java
+++ b/src/main/java/org/aibe4/dodeul/domain/board/model/dto/response/BoardPostDetailResponse.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import org.aibe4.dodeul.domain.board.model.entity.BoardPost;
 import org.aibe4.dodeul.domain.board.model.enums.PostStatus;
 import org.aibe4.dodeul.domain.common.model.entity.CommonFile;
+import org.aibe4.dodeul.domain.common.model.entity.SkillTag;
 import org.aibe4.dodeul.domain.consulting.model.enums.ConsultingTag;
 
 import java.time.LocalDateTime;
@@ -27,7 +28,8 @@ public record BoardPostDetailResponse(
     Boolean mine,
     Boolean canEdit,
     Boolean canDelete,
-    List<BoardPostFileResponse> files) {
+    List<BoardPostFileResponse> files,
+    List<String> skillTags) {
 
     @Builder
     public record BoardPostFileResponse(String fileName, String fileUrl, String contentType, Long size) {
@@ -56,6 +58,10 @@ public record BoardPostDetailResponse(
 
         boolean deleted = post.getPostStatus() == PostStatus.DELETED;
 
+        List<String> skillTagNames = post.getSkillTags().stream()
+            .map(SkillTag::getName)
+            .toList();
+
         return BoardPostDetailResponse.builder()
             .postId(post.getId())
             .title(post.getTitle())
@@ -73,6 +79,7 @@ public record BoardPostDetailResponse(
             .canEdit(mine && !deleted)
             .canDelete(mine && !deleted)
             .files(fileResponses)
+            .skillTags(skillTagNames)
             .build();
     }
 }

--- a/src/main/java/org/aibe4/dodeul/domain/board/model/dto/response/BoardPostScrapStatusResponse.java
+++ b/src/main/java/org/aibe4/dodeul/domain/board/model/dto/response/BoardPostScrapStatusResponse.java
@@ -1,0 +1,22 @@
+// src/main/java/org/aibe4/dodeul/domain/board/model/dto/response/BoardPostScrapStatusResponse.java
+package org.aibe4.dodeul.domain.board.model.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public class BoardPostScrapStatusResponse {
+
+    private final Long postId;
+    private final boolean scrappedByMe;
+    private final long scrapCount;
+
+    private BoardPostScrapStatusResponse(Long postId, boolean scrappedByMe, long scrapCount) {
+        this.postId = postId;
+        this.scrappedByMe = scrappedByMe;
+        this.scrapCount = scrapCount;
+    }
+
+    public static BoardPostScrapStatusResponse of(Long postId, boolean scrappedByMe, long scrapCount) {
+        return new BoardPostScrapStatusResponse(postId, scrappedByMe, scrapCount);
+    }
+}

--- a/src/main/java/org/aibe4/dodeul/domain/board/model/dto/response/BoardPostScrapToggleResponse.java
+++ b/src/main/java/org/aibe4/dodeul/domain/board/model/dto/response/BoardPostScrapToggleResponse.java
@@ -1,0 +1,22 @@
+// src/main/java/org/aibe4/dodeul/domain/board/model/dto/response/BoardPostScrapToggleResponse.java
+package org.aibe4.dodeul.domain.board.model.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public class BoardPostScrapToggleResponse {
+
+    private final Long postId;
+    private final boolean scrappedByMe;
+    private final long scrapCount;
+
+    private BoardPostScrapToggleResponse(Long postId, boolean scrappedByMe, long scrapCount) {
+        this.postId = postId;
+        this.scrappedByMe = scrappedByMe;
+        this.scrapCount = scrapCount;
+    }
+
+    public static BoardPostScrapToggleResponse of(Long postId, boolean scrappedByMe, long scrapCount) {
+        return new BoardPostScrapToggleResponse(postId, scrappedByMe, scrapCount);
+    }
+}

--- a/src/main/java/org/aibe4/dodeul/domain/board/model/dto/response/MyScrapItemResponse.java
+++ b/src/main/java/org/aibe4/dodeul/domain/board/model/dto/response/MyScrapItemResponse.java
@@ -1,0 +1,27 @@
+// src/main/java/org/aibe4/dodeul/domain/board/model/dto/response/MyScrapItemResponse.java
+package org.aibe4.dodeul.domain.board.model.dto.response;
+
+import lombok.Getter;
+import java.util.List;
+
+@Getter
+public class MyScrapItemResponse {
+
+    private final Long id;
+    private final String type;
+    private final String title;
+    private final String subText;
+    private final List<String> tags;
+
+    private MyScrapItemResponse(Long id, String type, String title, String subText, List<String> tags) {
+        this.id = id;
+        this.type = type;
+        this.title = title;
+        this.subText = subText;
+        this.tags = tags;
+    }
+
+    public static MyScrapItemResponse of(Long id, String type, String title, String subText, List<String> tags) {
+        return new MyScrapItemResponse(id, type, title, subText, tags);
+    }
+}

--- a/src/main/java/org/aibe4/dodeul/domain/board/model/dto/response/MyScrapListResponse.java
+++ b/src/main/java/org/aibe4/dodeul/domain/board/model/dto/response/MyScrapListResponse.java
@@ -1,0 +1,20 @@
+// src/main/java/org/aibe4/dodeul/domain/board/model/dto/response/MyScrapListResponse.java
+package org.aibe4.dodeul.domain.board.model.dto.response;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class MyScrapListResponse {
+
+    private final List<MyScrapItemResponse> items;
+
+    private MyScrapListResponse(List<MyScrapItemResponse> items) {
+        this.items = items;
+    }
+
+    public static MyScrapListResponse of(List<MyScrapItemResponse> items) {
+        return new MyScrapListResponse(items);
+    }
+}

--- a/src/main/java/org/aibe4/dodeul/domain/board/model/repository/BoardPostScrapRepository.java
+++ b/src/main/java/org/aibe4/dodeul/domain/board/model/repository/BoardPostScrapRepository.java
@@ -3,10 +3,26 @@ package org.aibe4.dodeul.domain.board.model.repository;
 
 import org.aibe4.dodeul.domain.board.model.entity.BoardPostScrap;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-@Repository
+import java.util.List;
+
 public interface BoardPostScrapRepository extends JpaRepository<BoardPostScrap, Long> {
 
     boolean existsByBoardPostIdAndMemberId(Long boardPostId, Long memberId);
+
+    long countByBoardPostId(Long boardPostId);
+
+    void deleteByBoardPostIdAndMemberId(Long boardPostId, Long memberId);
+
+    @Query(
+        """
+            select s
+            from BoardPostScrap s
+            join fetch s.boardPost p
+            where s.memberId = :memberId
+            order by s.id desc
+            """)
+    List<BoardPostScrap> findMyScrapsWithPost(@Param("memberId") Long memberId);
 }

--- a/src/main/java/org/aibe4/dodeul/domain/board/service/BoardPostScrapService.java
+++ b/src/main/java/org/aibe4/dodeul/domain/board/service/BoardPostScrapService.java
@@ -1,0 +1,129 @@
+// src/main/java/org/aibe4/dodeul/domain/board/service/BoardPostScrapService.java
+package org.aibe4.dodeul.domain.board.service;
+
+import lombok.RequiredArgsConstructor;
+import org.aibe4.dodeul.domain.board.model.dto.response.BoardPostScrapStatusResponse;
+import org.aibe4.dodeul.domain.board.model.dto.response.BoardPostScrapToggleResponse;
+import org.aibe4.dodeul.domain.board.model.dto.response.MyScrapItemResponse;
+import org.aibe4.dodeul.domain.board.model.dto.response.MyScrapListResponse;
+import org.aibe4.dodeul.domain.board.model.entity.BoardPost;
+import org.aibe4.dodeul.domain.board.model.entity.BoardPostScrap;
+import org.aibe4.dodeul.domain.board.model.enums.PostStatus;
+import org.aibe4.dodeul.domain.board.model.repository.BoardPostRepository;
+import org.aibe4.dodeul.domain.board.model.repository.BoardPostScrapRepository;
+import org.aibe4.dodeul.domain.common.model.entity.SkillTag;
+import org.aibe4.dodeul.domain.member.model.entity.Member;
+import org.aibe4.dodeul.domain.member.model.repository.MemberRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BoardPostScrapService {
+
+    private static final DateTimeFormatter SUBTEXT_DATE = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+    private final BoardPostRepository boardPostRepository;
+    private final BoardPostScrapRepository boardPostScrapRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public BoardPostScrapToggleResponse toggle(Long memberId, Long postId) {
+        BoardPost post = getActivePostOrThrow(postId);
+
+        boolean exists = boardPostScrapRepository.existsByBoardPostIdAndMemberId(postId, memberId);
+        if (exists) {
+            boardPostScrapRepository.deleteByBoardPostIdAndMemberId(postId, memberId);
+            post.decreaseScrapCount();
+        } else {
+            BoardPostScrap scrap = BoardPostScrap.builder().boardPost(post).memberId(memberId).build();
+            boardPostScrapRepository.save(scrap);
+            post.increaseScrapCount();
+        }
+
+        long scrapCount = boardPostScrapRepository.countByBoardPostId(postId);
+        boolean scrappedByMe = !exists;
+
+        return BoardPostScrapToggleResponse.of(postId, scrappedByMe, scrapCount);
+    }
+
+    @Transactional
+    public BoardPostScrapToggleResponse delete(Long memberId, Long postId) {
+        BoardPost post = getActivePostOrThrow(postId);
+
+        boolean exists = boardPostScrapRepository.existsByBoardPostIdAndMemberId(postId, memberId);
+        if (!exists) {
+            long scrapCount = boardPostScrapRepository.countByBoardPostId(postId);
+            return BoardPostScrapToggleResponse.of(postId, false, scrapCount);
+        }
+
+        boardPostScrapRepository.deleteByBoardPostIdAndMemberId(postId, memberId);
+        post.decreaseScrapCount();
+
+        long scrapCount = boardPostScrapRepository.countByBoardPostId(postId);
+        return BoardPostScrapToggleResponse.of(postId, false, scrapCount);
+    }
+
+    public BoardPostScrapStatusResponse getStatus(Long memberIdOrNull, Long postId) {
+        getActivePostOrThrow(postId);
+
+        long scrapCount = boardPostScrapRepository.countByBoardPostId(postId);
+        boolean scrappedByMe =
+            memberIdOrNull != null
+                && boardPostScrapRepository.existsByBoardPostIdAndMemberId(postId, memberIdOrNull);
+
+        return BoardPostScrapStatusResponse.of(postId, scrappedByMe, scrapCount);
+    }
+
+    public MyScrapListResponse getMyScraps(Long memberId) {
+        List<BoardPostScrap> scraps = boardPostScrapRepository.findMyScrapsWithPost(memberId);
+
+        List<MyScrapItemResponse> items =
+            scraps.stream()
+                .filter(s -> s.getBoardPost().getPostStatus() != PostStatus.DELETED) // 삭제된 게시글 필터링
+                .map(
+                    s -> {
+                        BoardPost p = s.getBoardPost();
+                        String date =
+                            p.getCreatedAt() == null
+                                ? "-"
+                                : p.getCreatedAt().toLocalDate().format(SUBTEXT_DATE);
+
+                        // 작성자 닉네임 조회
+                        String authorName = "익명";
+                        if (p.getMemberId() != null) {
+                            authorName = memberRepository.findById(p.getMemberId())
+                                .map(Member::getNickname)
+                                .orElse("익명");
+                        }
+
+                        // 스킬 태그 목록
+                        List<String> tagNames = p.getSkillTags().stream()
+                            .map(SkillTag::getName)
+                            .toList();
+
+                        String subText = String.format("작성자: %s · %s", authorName, date);
+                        return MyScrapItemResponse.of(p.getId(), "post", p.getTitle(), subText, tagNames);
+                    })
+                .toList();
+
+        return MyScrapListResponse.of(items);
+    }
+
+    private BoardPost getActivePostOrThrow(Long postId) {
+        BoardPost post =
+            boardPostRepository
+                .findById(postId)
+                .orElseThrow(() -> new IllegalArgumentException("게시글을 찾을 수 없습니다."));
+
+        if (post.getPostStatus() == PostStatus.DELETED) {
+            throw new IllegalStateException("삭제된 게시글입니다.");
+        }
+
+        return post;
+    }
+}

--- a/src/main/java/org/aibe4/dodeul/domain/board/service/BoardPostService.java
+++ b/src/main/java/org/aibe4/dodeul/domain/board/service/BoardPostService.java
@@ -229,14 +229,7 @@ public class BoardPostService {
     }
 
     private void validateListPolicy(Long memberId, BoardPostListRequest request) {
-        if (isDefaultListRequest(request)) {
-            return;
-        }
-
-        if (memberId == null) {
-            throw new BoardPolicyException(
-                ErrorCode.ACCESS_DENIED, "검색/필터 기능은 로그인 후 이용 가능합니다.");
-        }
+        // 로그인 정책 검증 로직 제거 (모든 사용자에게 필터 허용)
     }
 
     private boolean isDefaultListRequest(BoardPostListRequest request) {

--- a/src/main/resources/static/css/board/board-post-list.css
+++ b/src/main/resources/static/css/board/board-post-list.css
@@ -16,7 +16,6 @@
   --red: #ef4444;
   --red-bg: #fef2f2;
 
-  /* 버튼 톤(튀지 않게 블루 계열) */
   --primary: #2563eb;
   --primary-hover: #1d4ed8;
   --primary-soft: rgba(37, 99, 235, 0.1);
@@ -47,7 +46,7 @@ body {
 
 .board-list__header {
   display: flex;
-  align-items: center; /* 버튼/타이틀 세로 중앙 정렬 */
+  align-items: center;
   justify-content: space-between;
   gap: 16px;
   margin-bottom: 14px;
@@ -74,7 +73,7 @@ body {
 .board-list__actions {
   flex: 0 0 auto;
   display: flex;
-  align-items: center; /* 헤더 안에서 버튼이 위로 뜨는 현상 방지 */
+  align-items: center;
 }
 
 /* Common card */
@@ -103,10 +102,11 @@ body {
   flex-direction: column;
   gap: 6px;
   min-width: 160px;
+  flex: 1;
 }
 
 .field:first-child {
-  flex: 1 1 420px;
+  flex: 3;
   min-width: 240px;
 }
 
@@ -114,6 +114,11 @@ body {
   font-size: 12px;
   color: var(--muted);
   font-weight: 800;
+}
+
+.field__search {
+  display: flex;
+  gap: 8px;
 }
 
 .field__input,
@@ -125,6 +130,10 @@ body {
   outline: none;
   background: #fff;
   color: var(--text);
+}
+
+.field__input {
+  flex: 1;
 }
 
 .field__input:focus,
@@ -139,11 +148,126 @@ body {
   color: var(--muted);
 }
 
-/* Cards grid */
-.board-cards {
-  width: 100%;
+/* Body + Aside */
+.board-body {
+  display: flex;
+  align-items: flex-start;
+  gap: 18px;
 }
 
+.board-cards {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.board-aside {
+  flex: 0 0 320px;
+  position: sticky;
+  top: 18px;
+}
+
+.side {
+  padding: 14px;
+}
+
+.side__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--line);
+}
+
+.side__title {
+  font-size: 16px;
+  font-weight: 900;
+  letter-spacing: -0.2px;
+}
+
+.side__section {
+  padding-top: 12px;
+}
+
+.side__label {
+  font-size: 13px;
+  font-weight: 900;
+}
+
+.side__hint {
+  margin-top: 8px;
+  font-size: 12px;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.side__tagbox {
+  margin-top: 10px;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 8px;
+}
+
+.side__foot {
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid var(--line);
+}
+
+/* Tag checkbox row (wireframe 느낌) */
+.tagcheck {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 10px;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: #fff;
+  cursor: pointer;
+  user-select: none;
+}
+
+.tagcheck:hover {
+  border-color: rgba(17, 24, 39, 0.18);
+  box-shadow: 0 6px 18px rgba(17, 24, 39, 0.06);
+}
+
+.tagcheck__input {
+  position: absolute;
+  opacity: 0;
+}
+
+.tagcheck__box {
+  width: 18px;
+  height: 18px;
+  border-radius: 6px;
+  border: 1px solid rgba(17, 24, 39, 0.22);
+  background: #fff;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+}
+
+.tagcheck__text {
+  font-size: 13px;
+  font-weight: 800;
+  color: var(--text);
+}
+
+.tagcheck__input:checked + .tagcheck__box {
+  border-color: rgba(37, 99, 235, 0.35);
+  background: rgba(37, 99, 235, 0.1);
+}
+
+.tagcheck__input:checked + .tagcheck__box::after {
+  content: "✓";
+  font-size: 12px;
+  font-weight: 900;
+  color: var(--blue);
+}
+
+/* Cards grid */
 .board-cards__grid {
   width: 100%;
   display: grid;
@@ -154,6 +278,26 @@ body {
 
 @media (max-width: 1100px) {
   .board-cards__grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .board-aside {
+    flex-basis: 300px;
+  }
+}
+
+@media (max-width: 920px) {
+  .board-body {
+    flex-direction: column;
+  }
+
+  .board-aside {
+    position: static;
+    width: 100%;
+    flex-basis: auto;
+  }
+
+  .side__tagbox {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
@@ -179,6 +323,10 @@ body {
   }
 
   .board-cards__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .side__tagbox {
     grid-template-columns: 1fr;
   }
 }
@@ -301,6 +449,23 @@ body {
   white-space: nowrap;
 }
 
+.chip--more {
+  border-color: rgba(17, 24, 39, 0.12);
+  background: rgba(17, 24, 39, 0.04);
+  color: rgba(17, 24, 39, 0.7);
+}
+
+.chip--click {
+  cursor: pointer;
+  appearance: none;
+  outline: none;
+}
+
+.chip--click:hover {
+  border-color: rgba(37, 99, 235, 0.28);
+  background: rgba(37, 99, 235, 0.1);
+}
+
 /* Empty */
 .empty {
   background: #fff;
@@ -349,7 +514,6 @@ body {
   font-weight: 900;
   font-size: 13px;
 
-  /* 텍스트가 위로 뜨는 현상 방지 */
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -368,7 +532,6 @@ body {
   cursor: not-allowed;
 }
 
-/* 질문 작성 버튼: 블루 톤 */
 .btn--primary {
   background: var(--primary);
   color: #fff;
@@ -382,4 +545,17 @@ body {
 
 .btn--ghost {
   background: #fff;
+}
+
+.btn--sm {
+  height: 34px;
+  padding: 0 12px;
+  border-radius: 10px;
+  font-size: 12px;
+}
+
+.btn--icon {
+  width: 40px;
+  padding: 0;
+  font-size: 16px;
 }

--- a/src/main/resources/static/css/board/board-post.css
+++ b/src/main/resources/static/css/board/board-post.css
@@ -230,31 +230,122 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 10px;
+  gap: 12px;
   background: #fff;
   border: 1px solid var(--line);
   border-radius: 14px;
-  padding: 12px 12px;
+  padding: 14px 14px;
+  transition: all 0.15s ease;
+}
+
+.filechip:hover {
+  border-color: var(--primary);
+  background: rgba(59, 130, 246, 0.03);
+}
+
+/* 파일 타입별 스타일 */
+.filechip.type-pdf {
+  background: #fef2f2;
+  border-color: rgba(239, 68, 68, 0.2);
+}
+.filechip.type-pdf .filechip__icon {
+  background: #fff;
+  color: #ef4444;
+  border-color: rgba(239, 68, 68, 0.2);
+}
+
+.filechip.type-ppt {
+  background: #fff7ed;
+  border-color: rgba(249, 115, 22, 0.2);
+}
+.filechip.type-ppt .filechip__icon {
+  background: #fff;
+  color: #f97316;
+  border-color: rgba(249, 115, 22, 0.2);
+}
+
+.filechip.type-image {
+  background: #eff6ff;
+  border-color: rgba(37, 99, 235, 0.2);
+}
+.filechip.type-image .filechip__icon {
+  background: #fff;
+  color: #2563eb;
+  border-color: rgba(37, 99, 235, 0.2);
+}
+
+.filechip.type-text {
+  background: #ecfdf5;
+  border-color: rgba(22, 163, 74, 0.2);
+}
+.filechip.type-text .filechip__icon {
+  background: #fff;
+  color: #16a34a;
+  border-color: rgba(22, 163, 74, 0.2);
 }
 
 .filechip__left {
+  min-width: 0;
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.filechip__icon {
+  font-size: 18px;
+  flex-shrink: 0;
+  width: 38px;
+  height: 38px;
+  border-radius: 12px;
+  border: 1px solid var(--line);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #fafafa;
+}
+
+.filechip__info {
   min-width: 0;
   flex: 1;
 }
 
 .filechip__name {
   font-size: 13px;
-  font-weight: 900;
+  font-weight: 600;
   color: var(--text);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  margin-bottom: 3px;
 }
 
 .filechip__meta {
-  margin-top: 3px;
   font-size: 12px;
   color: var(--muted);
+}
+
+.filechip__remove {
+  flex-shrink: 0;
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--line);
+  border-radius: 50%;
+  background: #fff;
+  color: var(--muted);
+  font-size: 18px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  line-height: 1;
+}
+
+.filechip__remove:hover {
+  border-color: #ef4444;
+  background: #fef2f2;
+  color: #ef4444;
 }
 
 /* ===== Actions ===== */

--- a/src/main/resources/static/css/board/post-detail.css
+++ b/src/main/resources/static/css/board/post-detail.css
@@ -372,9 +372,14 @@ body {
 }
 
 .btn--primary {
-  background: #111827;
+  background: #2563eb;
   color: #fff;
-  border-color: #111827;
+  border-color: #2563eb;
+}
+
+.btn--primary:hover {
+  background: #1d4ed8;
+  border-color: #1d4ed8;
 }
 
 /* ===== 댓글/채택 UI ===== */
@@ -634,7 +639,8 @@ body {
 }
 
 .comment__acceptedMark {
-  display: inline-flex;
+  display: flex;
+  justify-content: flex-end;
   align-items: center;
   gap: 6px;
   font-size: 12px;
@@ -644,6 +650,7 @@ body {
   height: 24px;
   border-radius: 8px;
   white-space: nowrap;
+  margin-top: 8px;
 }
 
 /* ===== 게시글 메뉴(점 세개) ===== */
@@ -735,6 +742,7 @@ body {
   background: #fff;
   border-radius: 14px;
   padding: 12px 12px;
+  transition: all 0.2s ease;
 }
 
 .attachcard--clickable {
@@ -743,6 +751,59 @@ body {
 
 .attachcard:hover {
   background: rgba(17, 24, 39, 0.03);
+}
+
+/* 파일 타입별 카드 스타일 */
+.attachcard.type-pdf {
+  background: #fef2f2;
+  border-color: rgba(239, 68, 68, 0.2);
+}
+.attachcard.type-pdf:hover {
+  background: #fee2e2;
+}
+.attachcard.type-pdf .attachcard__icon {
+  background: #fff;
+  color: #ef4444;
+  border-color: rgba(239, 68, 68, 0.2);
+}
+
+.attachcard.type-ppt {
+  background: #fff7ed;
+  border-color: rgba(249, 115, 22, 0.2);
+}
+.attachcard.type-ppt:hover {
+  background: #ffedd5;
+}
+.attachcard.type-ppt .attachcard__icon {
+  background: #fff;
+  color: #f97316;
+  border-color: rgba(249, 115, 22, 0.2);
+}
+
+.attachcard.type-image {
+  background: #eff6ff;
+  border-color: rgba(37, 99, 235, 0.2);
+}
+.attachcard.type-image:hover {
+  background: #dbeafe;
+}
+.attachcard.type-image .attachcard__icon {
+  background: #fff;
+  color: #2563eb;
+  border-color: rgba(37, 99, 235, 0.2);
+}
+
+.attachcard.type-text {
+  background: #ecfdf5;
+  border-color: rgba(22, 163, 74, 0.2);
+}
+.attachcard.type-text:hover {
+  background: #d1fae5;
+}
+.attachcard.type-text .attachcard__icon {
+  background: #fff;
+  color: #16a34a;
+  border-color: rgba(22, 163, 74, 0.2);
 }
 
 .attachcard__icon {
@@ -810,6 +871,14 @@ body {
 
 .attachments__previewCloseBtn {
   padding: 8px 12px;
+  background: #2563eb;
+  color: #fff;
+  border-color: #2563eb;
+}
+
+.attachments__previewCloseBtn:hover {
+  background: #1d4ed8;
+  border-color: #1d4ed8;
 }
 
 .attachments__previewImage {

--- a/src/main/resources/static/css/global.css
+++ b/src/main/resources/static/css/global.css
@@ -40,9 +40,10 @@
   --color-text-secondary: #6c757d;
   --color-text-inverse: #FFFFFF;
 
-  --color-brand-primary: #212529;
+  /* Brand Colors (Blue) */
+  --color-brand-primary: #2563eb;
   --color-brand-secondary: #d0d4d9;
-  --color-brand-hover: #000000;
+  --color-brand-hover: #1d4ed8;
 
   --color-bg-page: #F8F9FA;
   --color-bg-surface: #FFFFFF;
@@ -280,6 +281,7 @@ footer {
 }
 .btn-primary-custom:hover {
   background-color: var(--color-brand-hover);
+  border-color: var(--color-brand-hover);
   transform: translateY(-1px);
   box-shadow: var(--shadow-sm);
   color: var(--color-text-inverse);

--- a/src/main/resources/templates/board/post-comment.html
+++ b/src/main/resources/templates/board/post-comment.html
@@ -2,18 +2,22 @@
 <!doctype html>
 <html xmlns:th="http://www.thymeleaf.org" lang="ko">
 <body>
+<!--
+  이 파일은 참고용 컴포넌트입니다.
+  실제 댓글 렌더링은 post-detail.html에서 Thymeleaf SSR로 처리됩니다.
+-->
 <section class="card card--soft" th:fragment="postCommentSection">
   <header class="card__header card__header--compact">
     <h2 class="subtitle">
       <span class="subtitle__icon">💬</span>
       <span>답변</span>
-      <span id="answerCount" class="subtitle__count">0</span>
+      <span th:text="${comments.size()}" class="subtitle__count">0</span>
       <span class="subtitle__suffix">개</span>
     </h2>
   </header>
 
   <!-- 댓글 작성 -->
-  <div class="composer">
+  <div th:if="${isAuthenticated}" class="composer">
     <textarea
       id="commentContent"
       class="composer__input"
@@ -24,11 +28,94 @@
     </div>
   </div>
 
-  <div class="comment-list" id="commentList"></div>
+  <!-- 댓글 목록 (서버 렌더링) -->
+  <div class="comment-list">
+    <div
+      th:each="comment : ${comments}"
+      class="comment"
+      th:classappend="${comment.accepted ? 'comment--accepted' : ''}"
+    >
+      <div class="comment__head">
+        <div class="comment__left">
+          <div class="comment__avatar" th:text="${#strings.substring(comment.authorDisplayName, 0, 1).toUpperCase()}">
+            A
+          </div>
+          <div class="comment__meta">
+            <div class="comment__topline">
+              <span class="comment__name" th:text="${comment.authorDisplayName}">익명</span>
 
-  <div class="comment-placeholder" id="commentHint" style="display:none;">
+              <!-- 역할 태그 색상 구분 -->
+              <span
+                th:if="${comment.authorRoleTag == '작성자'}"
+                class="comment__role"
+                style="background:#eff6ff;color:#2563eb;border-color:rgba(37,99,235,0.2)"
+              >작성자</span>
+              <span
+                th:if="${comment.authorRoleTag == '멘토'}"
+                class="comment__role"
+                style="background:#ecfdf5;color:#16a34a;border-color:rgba(22,163,74,0.18)"
+              >멘토</span>
+              <span
+                th:if="${comment.authorRoleTag == '멘티'}"
+                class="comment__role"
+                style="background:#fef2f2;color:#ef4444;border-color:rgba(239,68,68,0.18)"
+              >멘티</span>
+
+              <span class="comment__time"
+                    th:text="${#temporals.format(comment.createdAt, 'yyyy-MM-dd HH:mm')}">방금 전</span>
+            </div>
+            <div class="comment__badges" th:if="${comment.accepted}">
+              <span class="comment__badge comment__badge--accepted">✓ 채택됨</span>
+            </div>
+          </div>
+        </div>
+        <div class="comment__right">
+          <!-- 채택 버튼 -->
+          <button
+            th:if="${comment.canAccept}"
+            class="btn btn--accept"
+          >채택하기
+          </button>
+
+          <!-- 댓글 좋아요 버튼 -->
+          <button
+            th:if="${isAuthenticated}"
+            class="comment__iconBtn"
+            th:classappend="${comment.likedByMe ? 'iconbtn--active' : ''}"
+          >
+            <span class="comment__icon" th:text="${comment.likedByMe ? '❤️' : '🤍'}">🤍</span>
+            <span class="comment__iconCount" th:text="${comment.likeCount}">0</span>
+          </button>
+        </div>
+      </div>
+      <div class="comment__body" th:text="${comment.content}">댓글 내용</div>
+    </div>
+  </div>
+
+  <div th:if="${comments.isEmpty()}" class="comment-placeholder">
     댓글이 없습니다.
   </div>
 </section>
+
+<style>
+  /* 역할 태그 색상 정의 */
+  .comment__role--author {
+    background: #eff6ff !important;
+    color: #2563eb !important;
+    border-color: rgba(37, 99, 235, 0.2) !important;
+  }
+
+  .comment__role--mentor {
+    background: #ecfdf5 !important;
+    color: #16a34a !important;
+    border-color: rgba(22, 163, 74, 0.18) !important;
+  }
+
+  .comment__role--mentee {
+    background: #fef2f2 !important;
+    color: #ef4444 !important;
+    border-color: rgba(239, 68, 68, 0.18) !important;
+  }
+</style>
 </body>
 </html>

--- a/src/main/resources/templates/board/post-detail.html
+++ b/src/main/resources/templates/board/post-detail.html
@@ -1,100 +1,95 @@
 <!-- src/main/resources/templates/board/post-detail.html -->
 <!doctype html>
-<html xmlns:th="http://www.thymeleaf.org" lang="ko">
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:sec="http://www.thymeleaf.org/extras/spring-security"
+      lang="ko">
 <head>
   <meta charset="UTF-8"/>
-  <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"/>
-  <title>게시글 상세</title>
+  <title th:text="${post.title}">게시글 상세</title>
   <link rel="stylesheet" href="/css/board/post-detail.css"/>
 </head>
 <body>
 <main class="page">
   <section class="shell">
-    <a class="back" href="/board/posts" aria-label="목록으로">
+    <a th:href="@{/board/posts}" class="back">
       <span class="back__icon">←</span>
-      <span class="back__text">목록으로 돌아가기</span>
+      <span>목록으로</span>
     </a>
 
+    <!-- 게시글 카드 -->
     <article class="card">
       <header class="card__header">
         <div class="header__top">
-          <span id="statusBadge" class="badge badge--gray">-</span>
+          <span
+            th:class="${post.status.name() == 'OPEN' ? 'badge badge--blue' : 'badge badge--gray'}"
+            th:text="${post.status}"
+          >OPEN</span>
           <div class="header__spacer"></div>
-
           <div class="header__actions">
+            <div class="kpi">
+              <span class="kpi__item">
+                <span class="kpi__icon">👁</span>
+                <span th:text="${post.viewCount}">0</span>
+              </span>
+            </div>
+
+            <!-- 스크랩 버튼 (AJAX 토글) -->
             <button
               id="scrapBtn"
               class="iconbtn"
               type="button"
-              aria-label="스크랩"
-              aria-pressed="false"
+              th:classappend="${isScraped ? 'iconbtn--active' : ''}"
+              th:attr="data-post-id=${post.postId}, data-scraped=${isScraped}"
             >
-              <span class="iconbtn__icon">🔖</span>
-              <span id="scrapBtnCount" class="iconbtn__count">0</span>
+              <span class="iconbtn__icon" th:text="${isScraped ? '📌' : '🔖'}">🔖</span>
+              <span class="iconbtn__count" th:text="${post.scrapCount}">0</span>
             </button>
 
-            <div class="kpi">
-              <span class="kpi__item">
-                <span class="kpi__icon">👁</span>
-                <span id="viewCount">0</span>
-              </span>
-            </div>
-
-            <div id="postMenuWrap" class="comment__menuWrap post-menu-wrap" style="display:none;">
-              <button id="postMenuBtn" class="comment__iconBtn" type="button" aria-label="게시글 메뉴">
-                <span class="comment__icon">⋮</span>
-              </button>
-
-              <div id="postMenu" class="comment__menu post-menu" style="display:none;">
-                <div class="comment__menuList">
-                  <button id="postEditBtn" type="button" class="comment__menuItem">수정</button>
-                  <button
-                    id="postDeleteBtn"
-                    type="button"
-                    class="comment__menuItem comment__menuItem--danger"
-                  >
-                    삭제
-                  </button>
+            <!-- 게시글 메뉴 (작성자만) -->
+            <div
+              th:if="${isAuthor}"
+              class="post__menuWrap"
+            >
+              <button class="iconbtn" type="button" id="postMenuBtn">⋮</button>
+              <div class="post__menu" id="postMenu" style="display:none;">
+                <div class="post__menuList">
+                  <a th:href="@{/board/posts/{id}/edit(id=${post.postId})}" class="post__menuItem">수정하기</a>
+                  <button class="post__menuItem" id="deletePostBtn">삭제하기</button>
                 </div>
               </div>
             </div>
           </div>
         </div>
 
-        <h1 id="title" class="title">로딩중...</h1>
+        <h1 class="title" th:text="${post.title}">제목</h1>
 
         <div class="meta">
-          <span class="meta__pill" id="authorPill">
+          <span class="meta__pill">
             <span class="meta__label">작성자</span>
-            <span id="author" class="meta__value">-</span>
+            <span class="meta__value" th:text="${post.authorDisplayName != null ? post.authorDisplayName : '익명'}">-</span>
           </span>
-
-          <span class="meta__pill" id="consultingPill">
-            <span class="meta__label">상담분야</span>
-            <span id="consulting" class="meta__value">-</span>
+          <span class="meta__pill">
+            <span class="meta__label">분야</span>
+            <span class="meta__value" th:text="${post.consultingTag != null ? post.consultingTag.description : '-'}">-</span>
           </span>
-
           <span class="meta__date">
-            <span id="createdAt">-</span>
-            <span id="updatedAtWrap" class="meta__updated" style="display: none">
-              · 수정 <span id="updatedAt">-</span>
-            </span>
+            <span th:text="${#temporals.format(post.createdAt, 'yyyy-MM-dd HH:mm')}">-</span>
+            <span
+              th:if="${post.updatedAt != null && !#temporals.format(post.updatedAt, 'yyyy-MM-dd HH:mm').equals(#temporals.format(post.createdAt, 'yyyy-MM-dd HH:mm'))}"
+              class="meta__updated"
+              th:text="'(수정됨: ' + ${#temporals.format(post.updatedAt, 'yyyy-MM-dd HH:mm')} + ')'"
+            ></span>
           </span>
         </div>
 
         <div class="tagrow">
-          <div id="tagContainer" class="tags"></div>
-          <div class="counts">
-            <span class="counts__item">
-              <span class="counts__label">스크랩</span>
-              <span id="scrapCount" class="counts__value">0</span>
-            </span>
-            <span class="counts__dot">·</span>
-            <span class="counts__item">
-              <span class="counts__label">댓글</span>
-              <span id="commentCount" class="counts__value">0</span>
-            </span>
+          <div class="tags">
+            <span
+              th:each="tag : ${post.skillTags}"
+              class="chip"
+              th:text="${tag}"
+            ></span>
           </div>
         </div>
       </header>
@@ -102,1046 +97,585 @@
       <hr class="divider"/>
 
       <section class="content">
-        <div id="content" class="content__body">-</div>
+        <div class="content__body" th:text="${post.content}"></div>
+
+        <!-- 첨부파일 섹션 -->
+        <div
+          th:if="${post.files != null && !post.files.isEmpty()}"
+          class="attachments"
+        >
+          <div class="attachments__head">
+            <span class="attachments__title">첨부파일</span>
+            <span class="attachments__count" th:text="${post.files.size()} + '개'">0개</span>
+          </div>
+          <div class="attachments__list">
+            <div
+              th:each="file : ${post.files}"
+              class="attachcard attachcard--clickable"
+              th:classappend="${
+                 #strings.contains(file.contentType, 'pdf') ? 'type-pdf' :
+                 (#strings.contains(file.contentType, 'presentation') || #strings.contains(file.contentType, 'powerpoint') ? 'type-ppt' :
+                 (#strings.contains(file.contentType, 'image') ? 'type-image' :
+                 (#strings.contains(file.contentType, 'text') ? 'type-text' : '')))
+               }"
+              th:attr="data-url=${file.fileUrl}, data-type=${file.contentType}, data-name=${file.fileName}"
+              onclick="previewFile(this)"
+            >
+              <div class="attachcard__icon"
+                   th:text="${
+                     #strings.contains(file.contentType, 'pdf') ? '📄' :
+                     (#strings.contains(file.contentType, 'presentation') || #strings.contains(file.contentType, 'powerpoint') ? '📊' :
+                     (#strings.contains(file.contentType, 'image') ? '🖼️' :
+                     (#strings.contains(file.contentType, 'text') ? '📝' : '📎')))
+                   }"
+              >📎</div>
+              <div class="attachcard__body">
+                <div class="attachcard__name" th:text="${file.fileName}">파일명</div>
+                <div class="attachcard__meta" th:text="${file.contentType}">파일타입</div>
+              </div>
+              <div class="attachcard__go">→</div>
+            </div>
+          </div>
+
+          <!-- 미리보기 영역 -->
+          <div id="filePreview" class="attachments__preview">
+            <div class="attachments__previewHead">
+              <span class="attachments__previewTitle" id="previewTitle">파일명</span>
+              <button class="btn btn--primary attachments__previewCloseBtn" onclick="closePreview()">닫기</button>
+            </div>
+            <div id="previewContent"></div>
+          </div>
+        </div>
       </section>
     </article>
 
-    <section class="attachments" id="attachmentsSection" style="display: none">
-      <div class="attachments__head">
-        <div class="attachments__title">첨부파일</div>
-        <div class="attachments__count" id="attachmentsCount">0</div>
+    <!-- 댓글 섹션 (서버 렌더링) -->
+    <section class="card card--soft">
+      <header class="card__header card__header--compact">
+        <h2 class="subtitle">
+          <span class="subtitle__icon">💬</span>
+          <span>답변</span>
+          <span class="subtitle__count" th:text="${comments.size()}">0</span>
+          <span class="subtitle__suffix">개</span>
+        </h2>
+      </header>
+
+      <!-- 댓글 작성 (로그인 사용자만) -->
+      <div th:if="${isAuthenticated}" class="composer">
+        <textarea
+          id="commentContent"
+          class="composer__input"
+          placeholder="답변을 작성하세요..."
+          aria-label="답변 작성"
+        ></textarea>
+        <div class="composer__actions">
+          <button id="commentSubmitBtn" class="btn btn--primary" type="button">답변 작성</button>
+        </div>
       </div>
 
-      <div id="attachmentsList" class="attachments__list"></div>
-
-      <div id="attachmentsPreview" class="attachments__preview" style="display:none;">
-        <div class="attachments__previewHead">
-          <div id="previewTitle" class="attachments__previewTitle">미리보기</div>
-          <button id="previewCloseBtn" type="button" class="btn attachments__previewCloseBtn">닫기</button>
+      <div th:unless="${isAuthenticated}" class="composer">
+        <div style="text-align:center; padding:20px; color:var(--muted);">
+          <a th:href="@{/auth/login}" style="text-decoration:underline;">로그인</a>하여 답변을 작성하세요.
         </div>
-        <div id="previewBody" class="attachments__previewBody"></div>
+      </div>
+
+      <!-- 댓글 목록 (서버 렌더링) -->
+      <div class="comment-list">
+        <th:block th:each="comment : ${comments}">
+          <!-- 루트 댓글 -->
+          <div
+            class="comment"
+            th:classappend="${comment.accepted ? 'comment--accepted' : ''}"
+            th:attr="data-comment-id=${comment.commentId}"
+          >
+            <div class="comment__head">
+              <div class="comment__left">
+                <div class="comment__avatar" th:text="${#strings.substring(comment.authorDisplayName, 0, 1).toUpperCase()}">A</div>
+                <div class="comment__meta">
+                  <div class="comment__topline">
+                    <span class="comment__name" th:text="${comment.authorDisplayName}">익명</span>
+
+                    <!-- 역할 태그 (색상 구분) -->
+                    <span
+                      th:if="${comment.authorRoleTag == '작성자'}"
+                      class="comment__role"
+                      style="background:#eff6ff;color:#2563eb;border-color:rgba(37,99,235,0.2)"
+                    >작성자</span>
+                    <span
+                      th:if="${comment.authorRoleTag == '멘토'}"
+                      class="comment__role"
+                      style="background:#ecfdf5;color:#16a34a;border-color:rgba(22,163,74,0.18)"
+                    >멘토</span>
+                    <span
+                      th:if="${comment.authorRoleTag == '멘티'}"
+                      class="comment__role"
+                      style="background:#fef2f2;color:#ef4444;border-color:rgba(239,68,68,0.18)"
+                    >멘티</span>
+
+                    <span class="comment__time" th:text="${#temporals.format(comment.createdAt, 'yyyy-MM-dd HH:mm')}">방금 전</span>
+                    <span
+                      th:if="${comment.updatedAt != null && !#temporals.format(comment.updatedAt, 'yyyy-MM-dd HH:mm').equals(#temporals.format(comment.createdAt, 'yyyy-MM-dd HH:mm'))}"
+                      class="comment__time"
+                      th:text="'(수정됨: ' + ${#temporals.format(comment.updatedAt, 'yyyy-MM-dd HH:mm')} + ')'"
+                    ></span>
+                  </div>
+                </div>
+              </div>
+              <div class="comment__right">
+                <!-- 채택 버튼 (게시글 작성자만, 아직 채택 안된 댓글) -->
+                <button
+                  th:if="${comment.canAccept}"
+                  class="btn btn--accept"
+                  th:attr="data-comment-id=${comment.commentId}"
+                  onclick="acceptComment(this)"
+                >채택하기</button>
+
+                <!-- 댓글 좋아요 버튼 -->
+                <button
+                  th:if="${isAuthenticated}"
+                  class="comment__iconBtn"
+                  th:classappend="${comment.likedByMe ? 'iconbtn--active' : ''}"
+                  th:attr="data-comment-id=${comment.commentId}, data-liked=${comment.likedByMe}"
+                  onclick="toggleCommentLike(this)"
+                >
+                  <span class="comment__icon" th:text="${comment.likedByMe ? '❤️' : '🤍'}">🤍</span>
+                  <span class="comment__iconCount" th:text="${comment.likeCount}">0</span>
+                </button>
+
+                <!-- 댓글 메뉴 (본인 댓글만) -->
+                <div th:if="${comment.mine || comment.canReply}" class="comment__menuWrap">
+                  <button class="comment__iconBtn comment__menuBtn" onclick="toggleCommentMenu(this)">⋮</button>
+                  <div class="comment__menu" style="display:none;">
+                    <div class="comment__menuList">
+                      <button th:if="${comment.canReply}" class="comment__menuItem" onclick="showReplyForm(this)" th:attr="data-comment-id=${comment.commentId}">답글 달기</button>
+                      <button th:if="${comment.mine}" class="comment__menuItem" onclick="showEditForm(this)" th:attr="data-comment-id=${comment.commentId}">수정</button>
+                      <button th:if="${comment.mine}" class="comment__menuItem comment__menuItem--danger" onclick="deleteComment(this)" th:attr="data-comment-id=${comment.commentId}">삭제</button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="comment__body" th:text="${comment.content}">댓글 내용</div>
+
+            <!-- 채택됨 표시 (우측 하단) -->
+            <div th:if="${comment.accepted}" class="comment__acceptedMark">
+              ✓ 채택됨
+            </div>
+
+            <!-- 답글 입력 폼 (숨김) -->
+            <div class="comment__reply" style="display:none;">
+              <textarea class="comment__replyInput" placeholder="답글을 작성하세요..."></textarea>
+              <div class="comment__replyActions">
+                <button class="btn btn--ghost" onclick="hideReplyForm(this)">취소</button>
+                <button class="btn btn--primary" onclick="submitReply(this)" th:attr="data-parent-id=${comment.commentId}">등록</button>
+              </div>
+            </div>
+
+            <!-- 수정 입력 폼 (숨김) -->
+            <div class="comment__editor" style="display:none;">
+              <textarea class="comment__editorInput"></textarea>
+              <div class="comment__editorActions">
+                <button class="btn btn--ghost" onclick="hideEditForm(this)">취소</button>
+                <button class="btn btn--primary" onclick="submitEdit(this)" th:attr="data-comment-id=${comment.commentId}">수정 완료</button>
+              </div>
+            </div>
+          </div>
+
+          <!-- 대댓글 (들여쓰기) -->
+          <div
+            th:each="child : ${comment.children}"
+            class="comment comment--child"
+            style="margin-left: 40px; margin-top: 8px; background: #fafafa;"
+            th:attr="data-comment-id=${child.commentId}"
+          >
+            <div class="comment__head">
+              <div class="comment__left">
+                <div class="comment__avatar" style="width:28px; height:28px; font-size:12px;" th:text="${#strings.substring(child.authorDisplayName, 0, 1).toUpperCase()}">A</div>
+                <div class="comment__meta">
+                  <div class="comment__topline">
+                    <span class="comment__name" style="font-size:13px;" th:text="${child.authorDisplayName}">익명</span>
+
+                    <span
+                      th:if="${child.authorRoleTag == '작성자'}"
+                      class="comment__role"
+                      style="background:#eff6ff;color:#2563eb;border-color:rgba(37,99,235,0.2);font-size:11px;"
+                    >작성자</span>
+                    <span
+                      th:if="${child.authorRoleTag == '멘토'}"
+                      class="comment__role"
+                      style="background:#ecfdf5;color:#16a34a;border-color:rgba(22,163,74,0.18);font-size:11px;"
+                    >멘토</span>
+
+                    <span class="comment__time" style="font-size:11px;" th:text="${#temporals.format(child.createdAt, 'yyyy-MM-dd HH:mm')}">방금 전</span>
+                    <span
+                      th:if="${child.updatedAt != null && !#temporals.format(child.updatedAt, 'yyyy-MM-dd HH:mm').equals(#temporals.format(child.createdAt, 'yyyy-MM-dd HH:mm'))}"
+                      class="comment__time"
+                      style="font-size:11px;"
+                      th:text="'(수정됨: ' + ${#temporals.format(child.updatedAt, 'yyyy-MM-dd HH:mm')} + ')'"
+                    ></span>
+                  </div>
+                </div>
+              </div>
+              <div class="comment__right">
+                <button
+                  th:if="${isAuthenticated}"
+                  class="comment__iconBtn"
+                  style="height:28px; padding:0 8px;"
+                  th:classappend="${child.likedByMe ? 'iconbtn--active' : ''}"
+                  th:attr="data-comment-id=${child.commentId}, data-liked=${child.likedByMe}"
+                  onclick="toggleCommentLike(this)"
+                >
+                  <span class="comment__icon" style="font-size:12px;" th:text="${child.likedByMe ? '❤️' : '🤍'}">🤍</span>
+                  <span class="comment__iconCount" style="font-size:11px;" th:text="${child.likeCount}">0</span>
+                </button>
+
+                <div th:if="${child.mine}" class="comment__menuWrap">
+                  <button class="comment__iconBtn comment__menuBtn" style="height:28px;" onclick="toggleCommentMenu(this)">⋮</button>
+                  <div class="comment__menu" style="display:none;">
+                    <div class="comment__menuList">
+                      <button class="comment__menuItem" onclick="showEditForm(this)" th:attr="data-comment-id=${child.commentId}">수정</button>
+                      <button class="comment__menuItem comment__menuItem--danger" onclick="deleteComment(this)" th:attr="data-comment-id=${child.commentId}">삭제</button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="comment__body" style="font-size:13px;" th:text="${child.content}">대댓글 내용</div>
+
+            <!-- 수정 입력 폼 (숨김) -->
+            <div class="comment__editor" style="display:none;">
+              <textarea class="comment__editorInput"></textarea>
+              <div class="comment__editorActions">
+                <button class="btn btn--ghost" onclick="hideEditForm(this)">취소</button>
+                <button class="btn btn--primary" onclick="submitEdit(this)" th:attr="data-comment-id=${child.commentId}">수정 완료</button>
+              </div>
+            </div>
+          </div>
+        </th:block>
+      </div>
+
+      <div th:if="${comments.isEmpty()}" class="comment-placeholder">
+        댓글이 없습니다.
       </div>
     </section>
 
-    <div th:replace="~{board/post-comment :: postCommentSection}"></div>
-
-    <input type="hidden" id="postId" th:value="${postId}"/>
+    <!-- Hidden 데이터 -->
+    <input type="hidden" id="postId" th:value="${post.postId}"/>
+    <input type="hidden" id="isAuthenticated" th:value="${isAuthenticated}"/>
   </section>
 </main>
 
-<script>
-  (function () {
-    const postIdEl = document.getElementById("postId");
-    const postId = postIdEl ? postIdEl.value : "";
+<script th:inline="javascript">
+  /*<![CDATA[*/
+  const postId = [[${post.postId}]];
+  const isAuthenticated = [[${isAuthenticated}]];
 
-    const SUPABASE_PUBLIC_BASE = "https://dnpcfxbsyccwbfnmlaaq.supabase.co/storage/v1/object/public";
-    const SUPABASE_BUCKET = "files";
+  // === 파일 미리보기 ===
+  function previewFile(element) {
+    const url = element.getAttribute('data-url');
+    const type = element.getAttribute('data-type');
+    const name = element.getAttribute('data-name');
 
-    function pick(obj, path, fallback) {
-      try {
-        const v = path
-          .split(".")
-          .reduce((acc, key) => (acc == null ? null : acc[key]), obj);
-        return v ?? fallback;
-      } catch (e) {
-        return fallback;
-      }
-    }
+    const previewContainer = document.getElementById('filePreview');
+    const previewContent = document.getElementById('previewContent');
+    const previewTitle = document.getElementById('previewTitle');
 
-    function firstArrayValue(post, paths) {
-      for (const p of paths) {
-        const v = pick(post, p, null);
-        if (Array.isArray(v)) return v;
-      }
-      return [];
-    }
+    previewTitle.textContent = name;
+    previewContent.innerHTML = '';
 
-    function formatDate(value) {
-      if (!value) return "-";
-      const d = new Date(value);
-      if (isNaN(d.getTime())) return String(value);
-      const pad = (n) => String(n).padStart(2, "0");
-      return (
-        d.getFullYear() +
-        "-" +
-        pad(d.getMonth() + 1) +
-        "-" +
-        pad(d.getDate()) +
-        " " +
-        pad(d.getHours()) +
-        ":" +
-        pad(d.getMinutes())
-      );
-    }
-
-    function setStatusBadge(status) {
-      const el = document.getElementById("statusBadge");
-      const s = String(status || "-").toUpperCase();
-
-      el.classList.remove("badge--green", "badge--gray", "badge--red", "badge--blue");
-
-      if (s === "OPEN") {
-        el.classList.add("badge--blue");
-        el.textContent = "OPEN";
-        return;
-      }
-      if (s === "CLOSED") {
-        el.classList.add("badge--gray");
-        el.textContent = "CLOSED";
-        return;
-      }
-      if (s === "DELETED") {
-        el.classList.add("badge--red");
-        el.textContent = "DELETED";
-        return;
-      }
-
-      el.classList.add("badge--gray");
-      el.textContent = s;
-    }
-
-    function renderTags(post) {
-      const container = document.getElementById("tagContainer");
-      if (!container) return;
-      container.innerHTML = "";
-
-      const list1 = pick(post, "skillTags", null);
-      if (Array.isArray(list1) && list1.length > 0) {
-        list1.forEach((t) => {
-          const name = t && typeof t === "object" ? t.name ?? t.tagName ?? "" : String(t);
-          if (!name) return;
-          const chip = document.createElement("span");
-          chip.className = "chip";
-          chip.textContent = name;
-          container.appendChild(chip);
+    if (type.startsWith('image/')) {
+      const img = document.createElement('img');
+      img.src = url;
+      img.className = 'attachments__previewImage';
+      previewContent.appendChild(img);
+    } else if (type === 'application/pdf') {
+      const iframe = document.createElement('iframe');
+      iframe.src = url;
+      iframe.className = 'attachments__previewFrame';
+      previewContent.appendChild(iframe);
+    } else if (type.startsWith('text/') || type === 'application/json') {
+      fetch(url)
+        .then(res => res.text())
+        .then(text => {
+          const pre = document.createElement('pre');
+          pre.className = 'attachments__previewText';
+          pre.textContent = text;
+          previewContent.appendChild(pre);
+        })
+        .catch(() => {
+          previewContent.innerHTML = '<div class="attachments__previewUnsupported">텍스트를 불러올 수 없습니다.</div>';
         });
-        return;
-      }
-
-      const list2 = pick(post, "tags", null);
-      if (Array.isArray(list2) && list2.length > 0) {
-        list2.forEach((t) => {
-          const name = t && typeof t === "object" ? t.name ?? "" : String(t);
-          if (!name) return;
-          const chip = document.createElement("span");
-          chip.className = "chip";
-          chip.textContent = name;
-          container.appendChild(chip);
-        });
-      }
-    }
-
-    function getExtFromName(name) {
-      if (!name) return "";
-      const i = String(name).lastIndexOf(".");
-      return i >= 0 ? String(name).slice(i + 1).toLowerCase() : "";
-    }
-
-    function guessTypeByExt(ext) {
-      if (!ext) return "";
-      if (ext === "pdf") return "application/pdf";
-      if (ext === "txt" || ext === "log" || ext === "md") return "text/plain";
-      if (ext === "png") return "image/png";
-      if (ext === "jpg" || ext === "jpeg") return "image/jpeg";
-      if (ext === "gif") return "image/gif";
-      if (ext === "webp") return "image/webp";
-      return "";
-    }
-
-    function buildPublicUrlFromPath(path) {
-      if (!path) return "";
-      const p = String(path).replace(/^\/+/, "");
-      if (p.startsWith("http://") || p.startsWith("https://")) return p;
-
-      const normalized = p.startsWith(SUPABASE_BUCKET + "/")
-        ? p.substring((SUPABASE_BUCKET + "/").length)
-        : p;
-
-      return SUPABASE_PUBLIC_BASE + "/" + SUPABASE_BUCKET + "/" + normalized;
-    }
-
-    function normalizeFile(a) {
-      const obj = a && typeof a === "object" ? a : {};
-
-      const rawUrl =
-        obj.fileUrl ??
-        obj.url ??
-        obj.downloadUrl ??
-        obj.publicUrl ??
-        obj.presignedUrl ??
-        obj.s3Url ??
-        "";
-
-      const rawPath =
-        obj.path ??
-        obj.filePath ??
-        obj.storagePath ??
-        obj.key ??
-        obj.objectKey ??
-        "";
-
-      const fileName =
-        obj.fileName ??
-        obj.originFileName ??
-        obj.originalName ??
-        obj.name ??
-        "첨부파일";
-
-      const contentTypeRaw = (obj.fileType ?? obj.contentType ?? obj.mimeType ?? "").toString();
-      const ext = getExtFromName(fileName);
-      const guessed = guessTypeByExt(ext);
-
-      const fileUrl = rawUrl
-        ? buildPublicUrlFromPath(rawUrl)
-        : rawPath
-          ? buildPublicUrlFromPath(rawPath)
-          : "";
-
-      const contentType = contentTypeRaw || guessed || "";
-
-      const fileSizeRaw = obj.fileSize ?? obj.size ?? obj.bytes ?? null;
-      const fileSize = fileSizeRaw == null ? null : Number(fileSizeRaw);
-
-      return {
-        fileUrl: String(fileUrl || ""),
-        fileName: String(fileName || "첨부파일"),
-        contentType: String(contentType || ""),
-        fileSize: Number.isFinite(fileSize) ? fileSize : null,
-        ext: ext,
-      };
-    }
-
-    function openPreview(file) {
-      const wrap = document.getElementById("attachmentsPreview");
-      const title = document.getElementById("previewTitle");
-      const body = document.getElementById("previewBody");
-      const closeBtn = document.getElementById("previewCloseBtn");
-      if (!wrap || !title || !body || !closeBtn) return;
-
-      title.textContent = "미리보기 · " + (file.fileName || "첨부파일");
-      body.innerHTML = "";
-      wrap.style.display = "block";
-
-      closeBtn.onclick = () => {
-        wrap.style.display = "none";
-        body.innerHTML = "";
-      };
-
-      const url = file.fileUrl;
-      const type = (file.contentType || guessTypeByExt(file.ext) || "").toLowerCase();
-
-      if (type.startsWith("image/")) {
-        const img = document.createElement("img");
-        img.src = url;
-        img.alt = file.fileName || "첨부파일";
-        img.className = "attachments__previewImage";
-        body.appendChild(img);
-        return;
-      }
-
-      if (type === "application/pdf" || file.ext === "pdf") {
-        const iframe = document.createElement("iframe");
-        iframe.src = url;
-        iframe.className = "attachments__previewFrame";
-        body.appendChild(iframe);
-        return;
-      }
-
-      if (type.startsWith("text/") || file.ext === "txt" || file.ext === "md" || file.ext === "log") {
-        const pre = document.createElement("pre");
-        pre.className = "attachments__previewText";
-        pre.textContent = "불러오는 중...";
-        body.appendChild(pre);
-
-        fetch(url, {method: "GET"})
-          .then((r) => (r.ok ? r.text() : Promise.reject(r)))
-          .then((text) => {
-            pre.textContent = text;
-          })
-          .catch(() => {
-            pre.textContent = "텍스트를 불러오지 못했습니다. (다운로드로 확인해주세요)";
-          });
-        return;
-      }
-
-      const p = document.createElement("div");
-      p.className = "attachments__previewUnsupported";
-      p.innerHTML = `
-        <div class="attachments__previewUnsupportedText">브라우저에서 미리보기를 지원하지 않는 형식입니다.</div>
-        <a class="attachments__previewLink" href="${url}" target="_blank" rel="noopener">파일 열기/다운로드</a>
+    } else {
+      previewContent.innerHTML = `
+        <div class="attachments__previewUnsupported">
+          <div class="attachments__previewUnsupportedText">미리보기를 지원하지 않는 파일 형식입니다.</div>
+          <a href="${url}" target="_blank" class="attachments__previewLink">다운로드 / 새 창에서 열기</a>
+        </div>
       `;
-      body.appendChild(p);
     }
 
-    function renderAttachments(payload) {
-      const section = document.getElementById("attachmentsSection");
-      const list = document.getElementById("attachmentsList");
-      const countEl = document.getElementById("attachmentsCount");
-      const previewWrap = document.getElementById("attachmentsPreview");
-      const previewBody = document.getElementById("previewBody");
-      if (!section || !list || !countEl) return;
+    previewContainer.style.display = 'block';
 
-      if (previewWrap && previewBody) {
-        previewWrap.style.display = "none";
-        previewBody.innerHTML = "";
-      }
+    // 스크롤 이동
+    previewContainer.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  }
 
-      const atts = firstArrayValue(payload, [
-        "files",
-        "data.files",
-        "attachments",
-        "commonFiles",
-        "boardAttachments",
-        "data.attachments",
-        "data.commonFiles",
-        "data.boardAttachments",
-      ]).map(normalizeFile);
+  function closePreview() {
+    const previewContainer = document.getElementById('filePreview');
+    previewContainer.style.display = 'none';
+    document.getElementById('previewContent').innerHTML = '';
+  }
 
-      const valid = atts.filter((x) => x.fileUrl);
-
-      if (valid.length === 0) {
-        section.style.display = "none";
-        list.innerHTML = "";
-        countEl.innerText = "0";
-        return;
-      }
-
-      section.style.display = "block";
-      countEl.innerText = String(valid.length);
-      list.innerHTML = "";
-
-      valid.forEach((a) => {
-        const item = document.createElement("div");
-        item.className = "attachcard attachcard--clickable";
-
-        const icon =
-          (a.contentType && a.contentType.toLowerCase().startsWith("image/")) ||
-          a.ext === "png" ||
-          a.ext === "jpg" ||
-          a.ext === "jpeg" ||
-          a.ext === "gif" ||
-          a.ext === "webp"
-            ? "🖼"
-            : a.ext === "pdf"
-              ? "📕"
-              : a.ext === "txt" || a.ext === "md" || a.ext === "log"
-                ? "📝"
-                : "📄";
-
-        const sizeLabel =
-          a.fileSize == null
-            ? ""
-            : a.fileSize < 1024 * 1024
-              ? Math.round(a.fileSize / 1024) + "KB"
-              : (a.fileSize / (1024 * 1024)).toFixed(1) + "MB";
-
-        const meta =
-          (a.contentType ? a.contentType : "file") + (sizeLabel ? " · " + sizeLabel : "");
-
-        item.innerHTML = `
-          <div class="attachcard__icon">${icon}</div>
-          <div class="attachcard__body">
-            <div class="attachcard__name">${a.fileName}</div>
-            <div class="attachcard__meta">${meta}</div>
-          </div>
-          <div class="attachcard__go" role="button" aria-label="첨부파일 새창">↗</div>
-        `;
-
-        item.addEventListener("click", () => openPreview(a));
-
-        item.querySelector(".attachcard__go")?.addEventListener("click", (e) => {
-          e.stopPropagation();
-          window.open(a.fileUrl, "_blank", "noopener");
-        });
-
-        list.appendChild(item);
-      });
-    }
-
-    function getApiData(res) {
-      if (res && res.data != null) return res.data;
-      return res;
-    }
-
-    function findTokenFromStorage() {
-      const candidates = [
-        "accessToken",
-        "ACCESS_TOKEN",
-        "token",
-        "jwt",
-        "JWT",
-        "Authorization",
-        "authorization",
-      ];
-      for (const k of candidates) {
-        const v1 = localStorage.getItem(k);
-        if (v1) return v1;
-        const v2 = sessionStorage.getItem(k);
-        if (v2) return v2;
-      }
-      return null;
-    }
-
-    function buildAuthHeaders() {
-      const headers = {};
-      const raw = findTokenFromStorage();
-      if (!raw) return headers;
-
-      const token = String(raw).trim();
-      if (!token) return headers;
-
-      headers["Authorization"] = token.toLowerCase().startsWith("bearer ")
-        ? token
-        : "Bearer " + token;
-      return headers;
-    }
-
-    function fetchJson(url, options) {
-      const base = {
-        credentials: "include",
-        headers: {
-          Accept: "application/json",
-          ...(options && options.headers ? options.headers : {}),
-        },
-      };
-      return fetch(url, {...base, ...(options || {})}).then((r) =>
-        r.ok ? r.json() : Promise.reject(r)
-      );
-    }
-
-    function closeAllMenus() {
-      document.querySelectorAll(".comment__menu, #postMenu").forEach((m) => (m.style.display = "none"));
-    }
-
-    document.addEventListener("click", (e) => {
-      const t = e.target;
-      if (
-        t &&
-        t.closest &&
-        (t.closest(".comment__menuWrap") || t.closest("#postMenuWrap"))
-      ) {
-        return;
-      }
-      closeAllMenus();
-    });
-
-    if (!postId) {
-      document.getElementById("title").innerText = "게시글 ID가 없습니다.";
+  // === 스크랩 토글 (AJAX) ===
+  document.getElementById('scrapBtn')?.addEventListener('click', function() {
+    if (!isAuthenticated) {
+      alert('로그인이 필요합니다.');
+      window.location.href = '/auth/login';
       return;
     }
 
-    window.__POST_DETAIL__ = {
-      postId: postId,
-      postStatus: null,
-      acceptedCommentId: null,
-      scrappedByMe: false,
-    };
+    const isScraped = this.getAttribute('data-scraped') === 'true';
+    const method = isScraped ? 'DELETE' : 'POST';
 
-    const submitBtn = document.getElementById("commentSubmitBtn");
-    if (submitBtn) {
-      submitBtn.addEventListener("click", () => createRootComment());
-    }
+    fetch(`/api/board/posts/${postId}/scrap`, {
+      method: method,
+      credentials: 'include',
+      headers: {'Content-Type': 'application/json'}
+    })
+      .then(r => r.ok ? r.json() : Promise.reject(r))
+      .then(data => {
+        const newScraped = data.data?.scraped || !isScraped;
+        this.setAttribute('data-scraped', newScraped);
+        this.classList.toggle('iconbtn--active', newScraped);
+        this.querySelector('.iconbtn__icon').textContent = newScraped ? '📌' : '🔖';
 
-    const scrapBtn = document.getElementById("scrapBtn");
-    if (scrapBtn) {
-      scrapBtn.addEventListener("click", () => toggleScrap());
-    }
-
-    function setScrapUi(scrapCount, scrappedByMe) {
-      const cnt1 = document.getElementById("scrapCount");
-      const cnt2 = document.getElementById("scrapBtnCount");
-      const btn = document.getElementById("scrapBtn");
-
-      if (cnt1) cnt1.innerText = String(scrapCount ?? 0);
-      if (cnt2) cnt2.innerText = String(scrapCount ?? 0);
-
-      window.__POST_DETAIL__.scrappedByMe = !!scrappedByMe;
-      if (btn) {
-        btn.setAttribute("aria-pressed", String(!!scrappedByMe));
-        btn.classList.toggle("iconbtn--active", !!scrappedByMe);
-      }
-    }
-
-    function toggleScrap() {
-      const auth = buildAuthHeaders();
-
-      fetchJson("/api/board/posts/" + postId + "/scrap", {
-        method: "POST",
-        headers: {"Content-Type": "application/json", ...auth},
-        body: JSON.stringify({}),
+        const count = parseInt(this.querySelector('.iconbtn__count').textContent) || 0;
+        const newCount = newScraped ? count + 1 : count - 1;
+        this.querySelector('.iconbtn__count').textContent = newCount;
+        document.getElementById('scrapCountDisplay').textContent = newCount;
       })
-        .then((res) => {
-          const data = getApiData(res) || {};
-          const nextCount =
-            pick(data, "scrapCount", null) ??
-            pick(data, "count", null) ??
-            pick(data, "data.scrapCount", null);
+      .catch(() => alert('스크랩 처리에 실패했습니다.'));
+  });
 
-          const nextScrapped =
-            pick(data, "scrappedByMe", null) ??
-            pick(data, "scrapped", null) ??
-            pick(data, "data.scrappedByMe", null);
-
-          const fallbackCount = Number(document.getElementById("scrapBtnCount")?.innerText || "0");
-          const curr = !!window.__POST_DETAIL__.scrappedByMe;
-          const toggled = !curr;
-
-          setScrapUi(
-            nextCount != null
-              ? Number(nextCount)
-              : toggled
-                ? fallbackCount + 1
-                : Math.max(0, fallbackCount - 1),
-            nextScrapped != null ? !!nextScrapped : toggled
-          );
-        })
-        .catch((err) => {
-          if (err && (err.status === 401 || err.status === 403)) {
-            alert("로그인이 필요합니다.");
-            return;
-          }
-          alert("스크랩 처리 중 오류가 발생했습니다.");
-        });
+  // === 댓글 작성 (AJAX) ===
+  document.getElementById('commentSubmitBtn')?.addEventListener('click', function() {
+    const content = document.getElementById('commentContent').value.trim();
+    if (!content) {
+      alert('댓글 내용을 입력하세요.');
+      return;
     }
 
-    fetchJson("/api/board/posts/" + postId, {headers: {...buildAuthHeaders()}})
-      .then((res) => {
-        const post = getApiData(res);
-
-        if (!post) {
-          document.getElementById("title").innerText = "게시글을 찾을 수 없습니다.";
-          return;
-        }
-
-        document.getElementById("title").innerText = pick(post, "title", "-");
-        document.getElementById("content").innerText = pick(post, "content", "-");
-
-        const authorName =
-          pick(post, "author.nickname", null) ??
-          pick(post, "author.displayName", null) ??
-          pick(post, "authorName", null) ??
-          pick(post, "authorNickname", null) ??
-          pick(post, "authorDisplayName", null) ??
-          pick(post, "nickname", null) ??
-          "-";
-        document.getElementById("author").innerText = authorName;
-
-        const consultingObj =
-          pick(post, "consultingTagSummary", null) ?? pick(post, "consultingTag", null);
-        const consultingName =
-          (consultingObj &&
-            typeof consultingObj === "object" &&
-            (consultingObj.name ?? consultingObj.code)) ||
-          (typeof consultingObj === "string" ? consultingObj : "-");
-        document.getElementById("consulting").innerText = consultingName;
-
-        const status = pick(post, "postStatus", null) ?? pick(post, "status", "-");
-        setStatusBadge(status);
-
-        document.getElementById("viewCount").innerText = pick(post, "viewCount", 0);
-
-        const scrapCount = pick(post, "scrapCount", 0);
-        const scrappedByMe = !!pick(post, "scrappedByMe", false);
-        setScrapUi(scrapCount, scrappedByMe);
-
-        document.getElementById("commentCount").innerText = pick(post, "commentCount", 0);
-
-        const createdAt = pick(post, "createdAt", null);
-        document.getElementById("createdAt").innerText = formatDate(createdAt);
-
-        const updatedAt = pick(post, "updatedAt", null);
-        if (updatedAt) {
-          document.getElementById("updatedAtWrap").style.display = "inline";
-          document.getElementById("updatedAt").innerText = formatDate(updatedAt);
-        }
-
-        renderTags(post);
-        window.__POST_DETAIL__.postStatus = String(status || "").toUpperCase();
-
-        const canEdit = pick(post, "canEdit", false) === true;
-        const canDelete = pick(post, "canDelete", false) === true;
-
-        const postMenuWrap = document.getElementById("postMenuWrap");
-        const postMenuBtn = document.getElementById("postMenuBtn");
-        const postMenu = document.getElementById("postMenu");
-        const postEditBtn = document.getElementById("postEditBtn");
-        const postDeleteBtn = document.getElementById("postDeleteBtn");
-
-        if (postMenuWrap && postMenuBtn && postMenu) {
-          if (canEdit || canDelete) {
-            postMenuWrap.style.display = "inline-flex";
-
-            if (!canEdit && postEditBtn) postEditBtn.style.display = "none";
-            if (!canDelete && postDeleteBtn) postDeleteBtn.style.display = "none";
-
-            postMenuBtn.addEventListener("click", (e) => {
-              e.stopPropagation();
-              const isOpen = postMenu.style.display === "block";
-              closeAllMenus();
-              postMenu.style.display = isOpen ? "none" : "block";
-
-              if (postMenu.style.display === "block") {
-                postMenu.style.top = "40px";
-                postMenu.style.bottom = "auto";
-                const rect = postMenu.getBoundingClientRect();
-                if (rect.bottom > window.innerHeight) {
-                  postMenu.style.top = "auto";
-                  postMenu.style.bottom = "40px";
-                }
-              }
-            });
-
-            if (postEditBtn) {
-              postEditBtn.addEventListener("click", () => {
-                closeAllMenus();
-                window.location.href = "/board/posts/" + postId + "/edit";
-              });
-            }
-
-            if (postDeleteBtn) {
-              postDeleteBtn.addEventListener("click", () => {
-                closeAllMenus();
-
-                if (!confirm("게시글을 삭제할까요?")) return;
-
-                const auth = buildAuthHeaders();
-
-                fetchJson("/api/board/posts/" + postId, {
-                  method: "DELETE",
-                  headers: {...auth},
-                })
-                  .then(() => (window.location.href = "/board/posts"))
-                  .catch((err) => {
-                    if (err && (err.status === 401 || err.status === 403)) {
-                      alert("로그인이 필요합니다.");
-                      return;
-                    }
-                    alert("게시글 삭제에 실패했습니다.");
-                  });
-              });
-            }
-          } else {
-            postMenuWrap.style.display = "none";
-          }
-        }
-
-        const filesInDetail = pick(post, "files", null);
-        if (filesInDetail && Array.isArray(filesInDetail) && filesInDetail.length > 0) {
-          renderAttachments({files: filesInDetail});
-        }
+    fetch(`/api/board/posts/${postId}/comments`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({content: content})
+    })
+      .then(r => r.ok ? r.json() : Promise.reject(r))
+      .then(() => {
+        // alert 제거하고 바로 리로드
+        location.reload();
       })
-      .then(() =>
-        fetchJson("/api/board/posts/" + postId + "/files", {
-          headers: {...buildAuthHeaders()},
-        })
-          .then((res) => {
-            renderAttachments(getApiData(res));
-          })
-          .catch(() => {
-            renderAttachments({files: []});
-          })
-      )
-      .then(() => loadComments())
-      .catch(() => {
-        document.getElementById("title").innerText = "상세 조회 중 오류가 발생했습니다.";
-      });
+      .catch(() => alert('댓글 작성에 실패했습니다.'));
+  });
 
-    function loadComments() {
-      return fetchJson("/api/board/posts/" + postId + "/comments", {headers: {...buildAuthHeaders()}})
-        .then((res) => {
-          const data = getApiData(res);
-          const acceptedId = pick(data, "acceptedCommentId", null);
-          const roots = pick(data, "comments", []);
+  // === 답글 폼 토글 ===
+  function showReplyForm(btn) {
+    const commentEl = btn.closest('.comment');
+    const replyForm = commentEl.querySelector('.comment__reply');
+    replyForm.style.display = 'block';
 
-          window.__POST_DETAIL__.acceptedCommentId = acceptedId;
-          renderComments(Array.isArray(roots) ? roots : [], acceptedId);
-        })
-        .catch(() => {
-          const listEl = document.getElementById("commentList");
-          if (listEl) listEl.innerHTML = "";
-          const cnt = document.getElementById("answerCount");
-          if (cnt) cnt.innerText = "0";
-        });
+    // 메뉴 닫기
+    const menu = btn.closest('.comment__menu');
+    if (menu) menu.style.display = 'none';
+  }
+
+  function hideReplyForm(btn) {
+    const replyForm = btn.closest('.comment__reply');
+    replyForm.style.display = 'none';
+    replyForm.querySelector('textarea').value = '';
+  }
+
+  // === 답글 작성 ===
+  function submitReply(btn) {
+    const parentId = btn.getAttribute('data-parent-id');
+    const replyForm = btn.closest('.comment__reply');
+    const content = replyForm.querySelector('textarea').value.trim();
+
+    if (!content) {
+      alert('답글 내용을 입력하세요.');
+      return;
     }
 
-    function renderComments(rootComments, acceptedId) {
-      const answerCountEl = document.getElementById("answerCount");
-      if (answerCountEl) answerCountEl.innerText = String(rootComments.length);
-
-      const listEl = document.getElementById("commentList");
-      if (!listEl) return;
-      listEl.innerHTML = "";
-
-      rootComments.forEach((c) => {
-        listEl.appendChild(renderCommentItem(c, acceptedId, true));
-
-        const children = pick(c, "children", []);
-        if (Array.isArray(children) && children.length > 0) {
-          children.forEach((child) => {
-            const childEl = renderCommentItem(child, acceptedId, false);
-            childEl.style.marginLeft = "44px";
-            listEl.appendChild(childEl);
-          });
-        }
-      });
-    }
-
-    function renderCommentItem(c, acceptedId, isRoot) {
-      const commentId = pick(c, "commentId", null) ?? pick(c, "id", null);
-      const content = pick(c, "content", "");
-      const createdAt = pick(c, "createdAt", null);
-
-      const authorName =
-        pick(c, "authorNickname", null) ??
-        pick(c, "authorDisplayName", "-") ??
-        pick(c, "authorNickname", "-");
-
-      const roleTag = pick(c, "authorRoleTag", null);
-      const likeCount = pick(c, "likeCount", 0);
-
-      const canAccept = pick(c, "canAccept", false) === true;
-      const canEdit = pick(c, "canEdit", false) === true;
-      const canDelete = pick(c, "canDelete", false) === true;
-      const canReply = pick(c, "canReply", false) === true;
-
-      const isAccepted =
-        pick(c, "accepted", null) === true ||
-        (acceptedId != null && String(acceptedId) === String(commentId));
-
-      const item = document.createElement("article");
-      item.className = "comment";
-      if (isAccepted) item.classList.add("comment--accepted");
-      item.dataset.commentId = String(commentId || "");
-
-      const header = document.createElement("div");
-      header.className = "comment__head";
-
-      const left = document.createElement("div");
-      left.className = "comment__left";
-
-      const avatar = document.createElement("div");
-      avatar.className = "comment__avatar";
-      avatar.textContent = authorName && authorName.length > 0 ? authorName[0] : "👤";
-
-      const meta = document.createElement("div");
-      meta.className = "comment__meta";
-
-      const top = document.createElement("div");
-      top.className = "comment__topline";
-
-      const name = document.createElement("span");
-      name.className = "comment__name";
-      name.textContent = authorName;
-
-      const time = document.createElement("span");
-      time.className = "comment__time";
-      time.textContent = formatDate(createdAt);
-
-      top.appendChild(name);
-
-      if (roleTag) {
-        const role = document.createElement("span");
-        role.className = "comment__role";
-        role.textContent = roleTag;
-        top.appendChild(role);
-      }
-
-      top.appendChild(time);
-      meta.appendChild(top);
-
-      left.appendChild(avatar);
-      left.appendChild(meta);
-
-      const right = document.createElement("div");
-      right.className = "comment__right";
-
-      if (isAccepted) {
-        const acceptedMark = document.createElement("span");
-        acceptedMark.className = "comment__acceptedMark";
-        acceptedMark.textContent = "✓ 채택됨";
-        right.appendChild(acceptedMark);
-      }
-
-      const likeBtn = document.createElement("button");
-      likeBtn.className = "comment__iconBtn";
-      likeBtn.type = "button";
-      likeBtn.innerHTML = `<span class="comment__icon">♡</span><span class="comment__iconCount">${likeCount}</span>`;
-      likeBtn.addEventListener("click", () => {
-        fetchJson("/api/board/comments/" + commentId + "/likes/toggle", {
-          method: "POST",
-          headers: {...buildAuthHeaders()},
-        })
-          .then(() => loadComments())
-          .catch(() => alert("좋아요 처리 중 오류가 발생했습니다."));
-      });
-
-      const menuWrap = document.createElement("div");
-      menuWrap.className = "comment__menuWrap";
-
-      const menuBtn = document.createElement("button");
-      menuBtn.className = "comment__iconBtn";
-      menuBtn.type = "button";
-      menuBtn.innerHTML = `<span class="comment__icon">⋮</span>`;
-      menuBtn.addEventListener("click", (e) => {
-        e.stopPropagation();
-        const menu = menuWrap.querySelector(".comment__menu");
-        const isOpen = menu && menu.style.display === "block";
-        closeAllMenus();
-        if (!menu) return;
-
-        menu.style.display = isOpen ? "none" : "block";
-
-        if (menu.style.display === "block") {
-          menu.style.top = "40px";
-          menu.style.bottom = "auto";
-          const rect = menu.getBoundingClientRect();
-          if (rect.bottom > window.innerHeight) {
-            menu.style.top = "auto";
-            menu.style.bottom = "40px";
-          }
-        }
-      });
-
-      const menu = document.createElement("div");
-      menu.className = "comment__menu";
-      menu.style.display = "none";
-
-      const menuList = document.createElement("div");
-      menuList.className = "comment__menuList";
-
-      if (canEdit) {
-        const b = document.createElement("button");
-        b.type = "button";
-        b.className = "comment__menuItem";
-        b.textContent = "수정";
-        b.addEventListener("click", () => {
-          closeAllMenus();
-          openEdit(item, commentId, content);
-        });
-        menuList.appendChild(b);
-      }
-
-      if (canDelete) {
-        const b = document.createElement("button");
-        b.type = "button";
-        b.className = "comment__menuItem comment__menuItem--danger";
-        b.textContent = "삭제";
-        b.addEventListener("click", () => {
-          closeAllMenus();
-          deleteComment(commentId);
-        });
-        menuList.appendChild(b);
-      }
-
-      if (canReply) {
-        const b = document.createElement("button");
-        b.type = "button";
-        b.className = "comment__menuItem";
-        b.textContent = "답글 달기";
-        b.addEventListener("click", () => {
-          closeAllMenus();
-          openReply(item, commentId);
-        });
-        menuList.appendChild(b);
-      }
-
-      if (menuList.childNodes.length === 0) {
-        const empty = document.createElement("div");
-        empty.className = "comment__menuEmpty";
-        empty.textContent = "가능한 작업이 없습니다.";
-        menu.appendChild(empty);
-      } else {
-        menu.appendChild(menuList);
-      }
-
-      menuWrap.appendChild(menuBtn);
-      menuWrap.appendChild(menu);
-
-      if (isRoot) {
-        const acceptBtn = document.createElement("button");
-        acceptBtn.className = "btn btn--accept";
-        acceptBtn.type = "button";
-        acceptBtn.textContent = "채택하기";
-
-        if (!canAccept) {
-          acceptBtn.style.display = "none";
-        } else {
-          acceptBtn.addEventListener("click", () => acceptComment(commentId));
-        }
-        right.appendChild(acceptBtn);
-      }
-
-      right.appendChild(likeBtn);
-      right.appendChild(menuWrap);
-
-      header.appendChild(left);
-      header.appendChild(right);
-
-      const body = document.createElement("div");
-      body.className = "comment__body";
-      body.textContent = content;
-
-      item.appendChild(header);
-      item.appendChild(body);
-
-      return item;
-    }
-
-    function openEdit(commentEl, commentId, currentContent) {
-      const body = commentEl.querySelector(".comment__body");
-      if (!body) return;
-      if (commentEl.querySelector(".comment__editor")) return;
-
-      const editor = document.createElement("div");
-      editor.className = "comment__editor";
-
-      const ta = document.createElement("textarea");
-      ta.className = "comment__editorInput";
-      ta.value = currentContent || "";
-      editor.appendChild(ta);
-
-      const actions = document.createElement("div");
-      actions.className = "comment__editorActions";
-
-      const cancel = document.createElement("button");
-      cancel.type = "button";
-      cancel.className = "btn";
-      cancel.textContent = "취소";
-      cancel.addEventListener("click", () => {
-        editor.remove();
-        body.style.display = "";
-      });
-
-      const save = document.createElement("button");
-      save.type = "button";
-      save.className = "btn btn--primary";
-      save.textContent = "수정";
-      save.addEventListener("click", () => {
-        const next = String(ta.value || "").trim();
-        if (!next) {
-          alert("내용은 공백일 수 없습니다.");
-          return;
-        }
-
-        fetchJson("/api/board/comments/" + commentId, {
-          method: "PATCH",
-          headers: {"Content-Type": "application/json", ...buildAuthHeaders()},
-          body: JSON.stringify({content: next}),
-        })
-          .then(() => loadComments())
-          .catch(() => alert("댓글 수정에 실패했습니다."));
-      });
-
-      actions.appendChild(cancel);
-      actions.appendChild(save);
-      editor.appendChild(actions);
-
-      body.style.display = "none";
-      commentEl.appendChild(editor);
-    }
-
-    function openReply(commentEl, parentCommentId) {
-      if (commentEl.querySelector(".comment__reply")) return;
-
-      const reply = document.createElement("div");
-      reply.className = "comment__reply";
-
-      const ta = document.createElement("textarea");
-      ta.className = "comment__replyInput";
-      ta.placeholder = "답글을 입력하세요...";
-      reply.appendChild(ta);
-
-      const actions = document.createElement("div");
-      actions.className = "comment__replyActions";
-
-      const cancel = document.createElement("button");
-      cancel.type = "button";
-      cancel.className = "btn";
-      cancel.textContent = "취소";
-      cancel.addEventListener("click", () => reply.remove());
-
-      const submit = document.createElement("button");
-      submit.type = "button";
-      submit.className = "btn btn--primary";
-      submit.textContent = "답글 작성";
-      submit.addEventListener("click", () => {
-        const content = String(ta.value || "").trim();
-        if (!content) {
-          alert("내용은 공백일 수 없습니다.");
-          return;
-        }
-
-        fetchJson("/api/board/posts/" + postId + "/comments", {
-          method: "POST",
-          headers: {"Content-Type": "application/json", ...buildAuthHeaders()},
-          body: JSON.stringify({content: content, parentCommentId: parentCommentId}),
-        })
-          .then(() => loadComments())
-          .catch(() => alert("답글 작성에 실패했습니다."));
-      });
-
-      actions.appendChild(cancel);
-      actions.appendChild(submit);
-      reply.appendChild(actions);
-
-      commentEl.appendChild(reply);
-      ta.focus();
-    }
-
-    function deleteComment(commentId) {
-      if (!confirm("댓글을 삭제할까요?")) return;
-
-      fetchJson("/api/board/comments/" + commentId, {
-        method: "DELETE",
-        headers: {...buildAuthHeaders()},
+    fetch(`/api/board/posts/${postId}/comments`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({
+        content: content,
+        parentCommentId: parseInt(parentId)
       })
-        .then(() => loadComments())
-        .catch(() => alert("댓글 삭제에 실패했습니다."));
+    })
+      .then(r => r.ok ? r.json() : Promise.reject(r))
+      .then(() => {
+        // alert 제거하고 바로 리로드
+        location.reload();
+      })
+      .catch(() => alert('답글 작성에 실패했습니다.'));
+  }
+
+  // === 댓글 수정 폼 토글 ===
+  function showEditForm(btn) {
+    const commentEl = btn.closest('.comment');
+    const bodyEl = commentEl.querySelector('.comment__body');
+    const editForm = commentEl.querySelector('.comment__editor');
+    const textarea = editForm.querySelector('textarea');
+
+    // 기존 내용 불러오기
+    textarea.value = bodyEl.textContent;
+
+    bodyEl.style.display = 'none';
+    editForm.style.display = 'block';
+
+    // 메뉴 닫기
+    const menu = btn.closest('.comment__menu');
+    if (menu) menu.style.display = 'none';
+  }
+
+  function hideEditForm(btn) {
+    const commentEl = btn.closest('.comment');
+    const bodyEl = commentEl.querySelector('.comment__body');
+    const editForm = commentEl.querySelector('.comment__editor');
+
+    bodyEl.style.display = 'block';
+    editForm.style.display = 'none';
+  }
+
+  // === 댓글 수정 제출 ===
+  function submitEdit(btn) {
+    const commentId = btn.getAttribute('data-comment-id');
+    const editForm = btn.closest('.comment__editor');
+    const content = editForm.querySelector('textarea').value.trim();
+
+    if (!content) {
+      alert('내용을 입력하세요.');
+      return;
     }
 
-    function createRootComment() {
-      const textarea = document.getElementById("commentContent");
-      if (!textarea) return;
+    fetch(`/api/board/comments/${commentId}`, {
+      method: 'PATCH',
+      credentials: 'include',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({content: content})
+    })
+      .then(r => r.ok ? r.json() : Promise.reject(r))
+      .then(() => {
+        // alert 제거하고 바로 리로드
+        location.reload();
+      })
+      .catch(() => alert('수정에 실패했습니다.'));
+  }
 
-      const content = String(textarea.value || "").trim();
-      if (!content) {
-        alert("내용은 공백일 수 없습니다.");
-        return;
+  // === 댓글 좋아요 토글 ===
+  function toggleCommentLike(btn) {
+    const commentId = btn.getAttribute('data-comment-id');
+
+    fetch(`/api/board/comments/${commentId}/likes/toggle`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: {'Content-Type': 'application/json'}
+    })
+      .then(r => r.ok ? r.json() : Promise.reject(r))
+      .then(() => {
+        const isLiked = btn.getAttribute('data-liked') === 'true';
+        const newLiked = !isLiked;
+        btn.setAttribute('data-liked', newLiked);
+        btn.classList.toggle('iconbtn--active', newLiked);
+        btn.querySelector('.comment__icon').textContent = newLiked ? '❤️' : '🤍';
+
+        const countEl = btn.querySelector('.comment__iconCount');
+        const count = parseInt(countEl.textContent) || 0;
+        countEl.textContent = newLiked ? count + 1 : count - 1;
+      })
+      .catch(() => alert('좋아요 처리에 실패했습니다.'));
+  }
+
+  // === 댓글 채택 ===
+  function acceptComment(btn) {
+    const commentId = btn.getAttribute('data-comment-id');
+    if (!confirm('이 답변을 채택하시겠습니까?')) return;
+
+    fetch(`/api/board/posts/${postId}/accept`, {
+      method: 'PATCH',
+      credentials: 'include',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({commentId: parseInt(commentId)})
+    })
+      .then(r => r.ok ? r.json() : Promise.reject(r))
+      .then(() => {
+        alert('답변이 채택되었습니다.');
+        location.reload();
+      })
+      .catch(() => alert('채택에 실패했습니다.'));
+  }
+
+  // === 댓글 삭제 ===
+  function deleteComment(btn) {
+    const commentId = btn.getAttribute('data-comment-id');
+    if (!confirm('정말 삭제하시겠습니까?')) return;
+
+    fetch(`/api/board/comments/${commentId}`, {
+      method: 'DELETE',
+      credentials: 'include'
+    })
+      .then(r => r.ok ? r.json() : Promise.reject(r))
+      .then(() => {
+        alert('댓글이 삭제되었습니다.');
+        location.reload();
+      })
+      .catch(() => alert('삭제에 실패했습니다.'));
+  }
+
+  // === 댓글 메뉴 토글 ===
+  function toggleCommentMenu(btn) {
+    const menu = btn.nextElementSibling;
+    menu.style.display = menu.style.display === 'none' ? 'block' : 'none';
+  }
+
+  // === 게시글 메뉴 토글 ===
+  document.getElementById('postMenuBtn')?.addEventListener('click', () => {
+    const menu = document.getElementById('postMenu');
+    menu.style.display = menu.style.display === 'none' ? 'block' : 'none';
+  });
+
+  // === 게시글 삭제 ===
+  document.getElementById('deletePostBtn')?.addEventListener('click', () => {
+    if (!confirm('정말 삭제하시겠습니까?')) return;
+
+    fetch(`/api/board/posts/${postId}`, {
+      method: 'DELETE',
+      credentials: 'include'
+    })
+      .then(r => r.ok ? r.json() : Promise.reject(r))
+      .then(() => {
+        alert('삭제되었습니다.');
+        window.location.href = '/board/posts';
+      })
+      .catch(() => alert('삭제에 실패했습니다.'));
+  });
+
+  // === 외부 클릭 시 메뉴 닫기 ===
+  document.addEventListener('click', (e) => {
+    if (!e.target.closest('.post__menuWrap')) {
+      document.getElementById('postMenu')?.style && (document.getElementById('postMenu').style.display = 'none');
+    }
+    document.querySelectorAll('.comment__menu').forEach(menu => {
+      if (!e.target.closest('.comment__menuWrap')) {
+        menu.style.display = 'none';
       }
-
-      fetchJson("/api/board/posts/" + postId + "/comments", {
-        method: "POST",
-        headers: {"Content-Type": "application/json", ...buildAuthHeaders()},
-        body: JSON.stringify({content: content, parentCommentId: null}),
-      })
-        .then(() => {
-          textarea.value = "";
-          return loadComments();
-        })
-        .catch(() => alert("댓글 작성에 실패했습니다."));
-    }
-
-    function acceptComment(commentId) {
-      if (!commentId) return;
-
-      fetchJson("/api/board/posts/" + postId + "/accept", {
-        method: "PATCH",
-        headers: {"Content-Type": "application/json", ...buildAuthHeaders()},
-        body: JSON.stringify({commentId: commentId}),
-      })
-        .then((res) => {
-          const data = getApiData(res);
-
-          window.__POST_DETAIL__.postStatus = "CLOSED";
-          window.__POST_DETAIL__.acceptedCommentId =
-            data && data.acceptedCommentId != null ? data.acceptedCommentId : commentId;
-
-          setStatusBadge("CLOSED");
-          return loadComments();
-        })
-        .catch(() => alert("채택 처리 중 오류가 발생했습니다."));
-    }
-  })();
+    });
+  });
+  /*]]>*/
 </script>
 </body>
 </html>

--- a/src/main/resources/templates/board/post-edit.html
+++ b/src/main/resources/templates/board/post-edit.html
@@ -34,8 +34,7 @@
             <label class="board-post-label" for="consultingTag">분야</label>
             <select id="consultingTag" name="consultingTag" class="board-post-select">
               <option value="">선택하세요</option>
-              <option th:each="t : ${consultingTags}" th:value="${t.name()}" th:text="${t.description}">
-              </option>
+              <option th:each="t : ${consultingTags}" th:value="${t.name()}" th:text="${t.description}"></option>
             </select>
           </div>
 
@@ -73,6 +72,9 @@
             <div class="board-post-hint">
               예: Java, Spring, JPA (기존 기술 스택 외에 추가로 입력)
             </div>
+            <div id="duplicateWarning" class="board-post-error" style="display:none;">
+              중복된 태그가 있습니다: <span id="duplicateList"></span>
+            </div>
           </div>
 
           <div class="group">
@@ -91,7 +93,7 @@
 
             <div class="board-upload">
               <div class="board-upload__inner board-upload__inner--readonly">
-                <div class="board-upload__icon">📎</div>
+                <div class="board-upload__icon">🔒</div>
                 <div class="board-upload__text">첨부파일은 수정할 수 없습니다.</div>
                 <div class="board-upload__sub">파일 수정은 게시글을 삭제 후 재작성으로 가능합니다.</div>
               </div>
@@ -128,8 +130,7 @@
     }
 
     function getApiData(res) {
-      if (res && res.data != null) return res.data;
-      return res;
+      return (res && res.data != null) ? res.data : res;
     }
 
     function fetchJson(url, options) {
@@ -137,13 +138,45 @@
         credentials: "include",
         headers: {
           Accept: "application/json",
-          ...(options && options.headers ? options.headers : {}),
+          ...(options?.headers || {}),
         },
       };
       return fetch(url, {...base, ...(options || {})}).then((r) =>
         r.ok ? r.json() : Promise.reject(r),
       );
     }
+
+    // === 중복 태그 검증 ===
+    function checkDuplicateTags() {
+      const checkedTags = Array.from(document.querySelectorAll('input[name="skillTagIds"]:checked'))
+        .map(cb => String(cb.getAttribute("data-name") || "").trim().toLowerCase())
+        .filter(name => name.length > 0);
+
+      const textInput = document.getElementById("skillTagIdString").value || "";
+      const textTags = textInput
+        .split(",")
+        .map(s => s.trim().toLowerCase())
+        .filter(s => s.length > 0);
+
+      const duplicates = textTags.filter(tag => checkedTags.includes(tag));
+
+      const warning = document.getElementById("duplicateWarning");
+      const duplicateList = document.getElementById("duplicateList");
+
+      if (duplicates.length > 0) {
+        duplicateList.textContent = duplicates.join(", ");
+        warning.style.display = "block";
+        return false;
+      } else {
+        warning.style.display = "none";
+        return true;
+      }
+    }
+
+    document.getElementById("skillTagIdString")?.addEventListener("input", checkDuplicateTags);
+    document.querySelectorAll('input[name="skillTagIds"]').forEach(cb => {
+      cb.addEventListener("change", checkDuplicateTags);
+    });
 
     function setCheckedSkillTagsFromPost(post) {
       const checkboxList = Array.from(
@@ -269,6 +302,7 @@
 
     if (!postId) {
       alert("게시글 ID가 없습니다.");
+      window.location.href = "/board/posts";
       return;
     }
 
@@ -276,6 +310,7 @@
       window.location.href = "/board/posts/" + postId;
     });
 
+    // 게시글 정보 로드
     fetchJson("/api/board/posts/" + postId, {headers: {}})
       .then((res) => {
         const post = getApiData(res) || {};
@@ -303,10 +338,17 @@
       })
       .catch(() => {
         alert("게시글 정보를 불러오지 못했습니다.");
+        window.location.href = "/board/posts";
       });
 
+    // 수정 제출
     document.getElementById("editForm")?.addEventListener("submit", (e) => {
       e.preventDefault();
+
+      if (!checkDuplicateTags()) {
+        alert("중복된 태그를 제거해주세요.");
+        return;
+      }
 
       const title = String(document.getElementById("title")?.value || "").trim();
       const content = String(document.getElementById("content")?.value || "").trim();
@@ -327,12 +369,29 @@
         return;
       }
 
+      const skillTagIds = Array.from(
+        document.querySelectorAll('input[name="skillTagIds"]:checked')
+      ).map(cb => parseInt(cb.value));
+
+      const skillTagIdString = String(document.getElementById("skillTagIdString")?.value || "").trim();
+      const skillTagNames = skillTagIdString
+        .split(",")
+        .map(s => s.trim())
+        .filter(s => s.length > 0);
+
       fetchJson("/api/board/posts/" + postId, {
         method: "PATCH",
         headers: {"Content-Type": "application/json"},
-        body: JSON.stringify({title, content, consultingTag}),
+        body: JSON.stringify({
+          title,
+          content,
+          consultingTag,
+          skillTagIds,
+          skillTagNames
+        }),
       })
         .then(() => {
+          alert("수정되었습니다.");
           window.location.href = "/board/posts/" + postId;
         })
         .catch((err) => {

--- a/src/main/resources/templates/board/post-form.html
+++ b/src/main/resources/templates/board/post-form.html
@@ -44,7 +44,7 @@
             ></div>
           </div>
 
-          <!-- 분야 (수정하기 폼과 동일: value=name(), text=description) -->
+          <!-- 분야 -->
           <div class="group">
             <label class="board-post-label" for="consultingTag">분야</label>
             <select
@@ -81,6 +81,7 @@
                     class="board-post-tag-checkbox"
                     th:value="${tag.id}"
                     th:attr="data-name=${tag.name}"
+                    th:checked="${form.skillTagIds != null && #lists.contains(form.skillTagIds, tag.id)}"
                   />
                   <span class="board-post-tag-name" th:text="${tag.name}"></span>
                 </label>
@@ -101,6 +102,9 @@
             />
             <div class="board-post-hint">
               예: Java, Spring, JPA (기존 기술 스택 외에 추가로 입력)
+            </div>
+            <div id="duplicateWarning" class="board-post-error" style="display:none;">
+              중복된 태그가 있습니다: <span id="duplicateList"></span>
             </div>
           </div>
 
@@ -149,7 +153,7 @@
             </div>
           </div>
 
-          <!-- 액션 (수정하기 폼 톤과 동일: 버튼 2개) -->
+          <!-- 액션 -->
           <div class="board-post-actions">
             <button id="cancelBtn" type="button" class="btn btn--ghost">취소</button>
             <button type="submit" class="btn btn--primary">등록</button>
@@ -162,25 +166,102 @@
 </main>
 
 <script>
-  // ===== 취소 =====
-  document.getElementById("cancelBtn")?.addEventListener("click", () => {
-    window.location.href = "/board/posts";
+  // === 취소 ===
+  document.getElementById('cancelBtn')?.addEventListener('click', () => {
+    window.location.href = '/board/posts';
   });
 
-  // ===== 업로드 검증 + 리스트(칩) =====
+  // === 중복 태그 검증 ===
+  function checkDuplicateTags() {
+    const checkedTags = Array.from(document.querySelectorAll('input[name="skillTagIds"]:checked'))
+      .map(cb => String(cb.getAttribute("data-name") || "").trim().toLowerCase())
+      .filter(name => name.length > 0);
+
+    const textInput = document.getElementById("skillTagIdString").value || "";
+    const textTags = textInput
+      .split(",")
+      .map(s => s.trim().toLowerCase())
+      .filter(s => s.length > 0);
+
+    const duplicates = textTags.filter(tag => checkedTags.includes(tag));
+
+    const warning = document.getElementById("duplicateWarning");
+    const duplicateList = document.getElementById("duplicateList");
+
+    if (duplicates.length > 0) {
+      duplicateList.textContent = duplicates.join(", ");
+      warning.style.display = "block";
+      return false;
+    } else {
+      warning.style.display = "none";
+      return true;
+    }
+  }
+
+  document.getElementById("skillTagIdString")?.addEventListener("input", checkDuplicateTags);
+  document.querySelectorAll('input[name="skillTagIds"]').forEach(cb => {
+    cb.addEventListener("change", checkDuplicateTags);
+  });
+
+  // === 폼 제출 전 유효성 검사 (파일/태그 유지용) ===
+  document.getElementById("createForm")?.addEventListener("submit", (e) => {
+    // 1. 중복 태그 검사
+    if (!checkDuplicateTags()) {
+      e.preventDefault();
+      alert("중복된 태그를 제거해주세요.");
+      return false;
+    }
+
+    // 2. 필수값 검사 (제목, 분야, 본문)
+    const title = document.getElementById("title").value.trim();
+    const consultingTag = document.getElementById("consultingTag").value;
+    const content = document.getElementById("content").value.trim();
+
+    if (!title) {
+      e.preventDefault();
+      alert("제목을 입력해주세요.");
+      document.getElementById("title").focus();
+      return false;
+    }
+
+    if (!consultingTag) {
+      e.preventDefault();
+      alert("분야를 선택해주세요.");
+      document.getElementById("consultingTag").focus();
+      return false;
+    }
+
+    if (!content) {
+      e.preventDefault();
+      alert("본문을 입력해주세요.");
+      document.getElementById("content").focus();
+      return false;
+    }
+
+    if (content.length < 10) {
+      e.preventDefault();
+      alert("본문은 10자 이상 입력해야 합니다.");
+      document.getElementById("content").focus();
+      return false;
+    }
+  });
+
+  // === 파일 업로드 ===
   const MAX_FILES = 5;
-  const MAX_SIZE = 10 * 1024 * 1024; // 10MB
+  const MAX_SIZE = 10 * 1024 * 1024;
   const ALLOWED_EXT = /(\.jpg|\.jpeg|\.png|\.gif|\.pdf|\.txt|\.ppt|\.pptx)$/i;
 
   const input = document.getElementById("files");
   const uploadBox = document.getElementById("uploadBox");
   const uploadInner = document.getElementById("uploadInner");
 
+  // 현재 선택된 파일들을 저장하는 배열 (DataTransfer 대신 사용)
+  let currentFiles = [];
+
   function formatBytes(bytes) {
     if (!bytes && bytes !== 0) return "";
     const units = ["B", "KB", "MB", "GB"];
-    let b = bytes;
-    let i = 0;
+    let b = bytes, i = 0;
     while (b >= 1024 && i < units.length - 1) {
       b /= 1024;
       i += 1;
@@ -199,40 +280,74 @@
 
   function validateFiles(fileList) {
     if (!fileList || fileList.length === 0) return true;
-
     if (fileList.length > MAX_FILES) {
       alert("첨부파일은 최대 5개까지 가능합니다.");
       return false;
     }
-
     for (const file of fileList) {
       if (file.size > MAX_SIZE) {
-        alert("파일 크기는 10MB를 초과할 수 없습니다.");
+        alert(`${file.name}의 크기가 10MB를 초과합니다.`);
         return false;
       }
       if (!ALLOWED_EXT.exec(file.name)) {
-        alert("허용되지 않는 파일 형식입니다.\n(이미지, PDF, TXT, PPT 파일만 가능)");
+        alert(`${file.name}는 허용되지 않는 파일 형식입니다.`);
         return false;
       }
     }
     return true;
   }
 
+  // 중복 제거 (파일명 기준)
+  function removeDuplicateFiles(fileList) {
+    const seen = new Map();
+    const result = [];
+
+    for (const file of fileList) {
+      if (!seen.has(file.name)) {
+        seen.set(file.name, true);
+        result.push(file);
+      }
+    }
+
+    return result;
+  }
+
+  function getFileIcon(type) {
+    if (type.includes('pdf')) return '📄';
+    if (type.includes('presentation') || type.includes('powerpoint')) return '📊';
+    if (type.includes('image')) return '🖼️';
+    if (type.includes('text')) return '📝';
+    return '📎';
+  }
+
+  function getFileTypeClass(type) {
+    if (type.includes('pdf')) return 'type-pdf';
+    if (type.includes('presentation') || type.includes('powerpoint')) return 'type-ppt';
+    if (type.includes('image')) return 'type-image';
+    if (type.includes('text')) return 'type-text';
+    return '';
+  }
+
   function renderFileList() {
     const list = document.getElementById("fileList");
-    if (!list || !input) return;
+    if (!list) return;
 
     list.innerHTML = "";
-    const files = input.files ? Array.from(input.files) : [];
-    if (files.length === 0) return;
+    if (currentFiles.length === 0) return;
 
-    files.forEach((f, idx) => {
+    currentFiles.forEach((f, idx) => {
       const chip = document.createElement("div");
-      chip.className = "filechip";
+      const typeClass = getFileTypeClass(f.type);
+      const icon = getFileIcon(f.type);
+
+      chip.className = `filechip ${typeClass}`;
       chip.innerHTML = `
         <div class="filechip__left">
-          <div class="filechip__name">${escapeHtml(f.name)}</div>
-          <div class="filechip__meta">${escapeHtml(f.type || "file")} · ${formatBytes(f.size)}</div>
+          <div class="filechip__icon">${icon}</div>
+          <div class="filechip__info">
+            <div class="filechip__name">${escapeHtml(f.name)}</div>
+            <div class="filechip__meta">${formatBytes(f.size)}</div>
+          </div>
         </div>
         <button type="button" class="filechip__remove" aria-label="파일 제거" data-idx="${idx}">×</button>
       `;
@@ -242,38 +357,47 @@
     list.querySelectorAll(".filechip__remove").forEach((btn) => {
       btn.addEventListener("click", () => {
         const removeIdx = Number(btn.getAttribute("data-idx"));
-        const dt = new DataTransfer();
-        Array.from(input.files).forEach((f, i) => {
-          if (i !== removeIdx) dt.items.add(f);
-        });
-        input.files = dt.files;
+        currentFiles.splice(removeIdx, 1);
+        updateInputFiles();
         renderFileList();
       });
     });
   }
 
-  function setFiles(files) {
+  function updateInputFiles() {
     if (!input) return;
-
-    const list = Array.from(files || []);
-    if (!validateFiles(list)) return;
-
     const dt = new DataTransfer();
-    list.forEach((f) => dt.items.add(f));
+    currentFiles.forEach((f) => dt.items.add(f));
     input.files = dt.files;
+  }
+
+  function addFiles(newFiles) {
+    // 기존 파일 + 새 파일 병합
+    const merged = currentFiles.concat(newFiles);
+
+    // 중복 제거
+    const uniqueFiles = removeDuplicateFiles(merged);
+
+    // 유효성 검사
+    if (!validateFiles(uniqueFiles)) {
+      // 실패 시 input 초기화 (기존 파일 유지)
+      updateInputFiles();
+      return;
+    }
+
+    currentFiles = uniqueFiles;
+    updateInputFiles();
     renderFileList();
   }
 
   // 클릭으로 파일 선택
   uploadInner?.addEventListener("click", () => input?.click());
+
   input?.addEventListener("change", () => {
-    const files = input.files ? Array.from(input.files) : [];
-    if (!validateFiles(files)) {
-      input.value = "";
-      renderFileList();
-      return;
-    }
-    renderFileList();
+    const newFiles = input.files ? Array.from(input.files) : [];
+    if (newFiles.length === 0) return;
+
+    addFiles(newFiles);
   });
 
   // Drag & Drop
@@ -294,11 +418,7 @@
       const dropped = e.dataTransfer && e.dataTransfer.files ? Array.from(e.dataTransfer.files) : [];
       if (dropped.length === 0) return;
 
-      const current = input.files ? Array.from(input.files) : [];
-      const merged = current.concat(dropped);
-      if (!validateFiles(merged)) return;
-
-      setFiles(merged);
+      addFiles(dropped);
     });
   }
 </script>

--- a/src/main/resources/templates/board/post-list.html
+++ b/src/main/resources/templates/board/post-list.html
@@ -22,240 +22,180 @@
       </div>
 
       <div class="board-list__actions">
-        <a class="btn btn--primary" href="/board/posts/new">질문 작성</a>
+        <a class="btn btn--primary" th:href="@{/board/posts/new}">질문 작성</a>
       </div>
     </header>
 
-    <section class="board-filters card">
+    <!-- 상단 필터 영역 (Form 태그 제거, JS 처리) -->
+    <div class="board-filters card">
       <div class="board-filters__row">
         <div class="field">
-          <label class="field__label" for="keyword">검색</label>
-          <input id="keyword" class="field__input" type="text" placeholder="제목/본문 키워드"/>
+          <label class="field__label" for="keywordInput">검색</label>
+          <div class="field__search">
+            <input
+              id="keywordInput"
+              class="field__input"
+              type="text"
+              placeholder="제목/본문 키워드"
+              th:value="${param.keyword}"
+              onkeydown="if(event.key === 'Enter') { event.preventDefault(); applyFilters(); }"
+            />
+            <button type="button" class="btn btn--icon" aria-label="검색" onclick="applyFilters()">🔍</button>
+          </div>
         </div>
 
         <div class="field">
-          <label class="field__label" for="status">상태</label>
-          <select id="status" class="field__select">
+          <label class="field__label" for="statusSelect">상태</label>
+          <select id="statusSelect" class="field__select" onchange="applyFilters()">
             <option value="">전체</option>
-            <option value="OPEN">OPEN</option>
-            <option value="CLOSED">CLOSED</option>
+            <option value="OPEN" th:selected="${param.status != null && param.status[0] == 'OPEN'}">OPEN</option>
+            <option value="CLOSED" th:selected="${param.status != null && param.status[0] == 'CLOSED'}">CLOSED</option>
           </select>
         </div>
 
         <div class="field">
-          <label class="field__label" for="sort">정렬</label>
-          <select id="sort" class="field__select">
-            <option value="LATEST">최신순</option>
-            <option value="VIEW">조회수순</option>
-            <option value="SCRAP">스크랩순</option>
-            <option value="COMMENTED">최근댓글순</option>
+          <label class="field__label" for="sortSelect">정렬</label>
+          <select id="sortSelect" class="field__select" onchange="applyFilters()">
+            <option value="LATEST" th:selected="${param.sort == null || param.sort[0] == 'LATEST'}">최신순</option>
+            <option value="VIEWS" th:selected="${param.sort != null && param.sort[0] == 'VIEWS'}">조회수순</option>
+            <option value="SCRAPS" th:selected="${param.sort != null && param.sort[0] == 'SCRAPS'}">스크랩순</option>
           </select>
         </div>
 
-        <button id="applyBtn" class="btn" type="button">적용</button>
-        <button id="resetBtn" class="btn btn--ghost" type="button">초기화</button>
+        <a th:href="@{/board/posts}" class="btn btn--ghost">초기화</a>
       </div>
 
       <div class="board-filters__hint">
         검색/필터 사용 시 로그인 정책이 적용될 수 있습니다.
       </div>
-    </section>
+    </div>
 
-    <section class="board-cards" aria-live="polite">
-      <div id="emptyState" class="empty" style="display:none;">
-        <div class="empty__title">게시글이 없습니다.</div>
-        <div class="empty__desc">첫 질문을 작성해보세요.</div>
-      </div>
+    <div class="board-body">
+      <!-- 게시글 카드 그리드 -->
+      <section class="board-cards">
+        <!-- 빈 상태 -->
+        <div th:if="${posts == null || posts.isEmpty()}" class="empty">
+          <div class="empty__title">게시글이 없습니다.</div>
+          <div class="empty__desc">첫 질문을 작성해보세요.</div>
+        </div>
 
-      <div id="cardList" class="board-cards__grid"></div>
-    </section>
+        <!-- 게시글 목록 -->
+        <div th:unless="${posts == null || posts.isEmpty()}" class="board-cards__grid">
+          <a
+            th:each="post : ${posts}"
+            th:href="@{/board/posts/{id}(id=${post.postId})}"
+            class="postcard"
+          >
+            <div class="postcard__top">
+              <span
+                th:class="${post.postStatus == 'OPEN' ? 'badge badge--blue' : 'badge badge--gray'}"
+                th:text="${post.postStatus}"
+              ></span>
+              <span class="postcard__date" th:text="${#temporals.format(post.createdAt, 'yyyy-MM-dd')}"></span>
+            </div>
 
-    <nav class="pager" aria-label="페이지네이션">
-      <button id="prevBtn" class="btn btn--ghost" type="button">이전</button>
+            <div class="postcard__title" th:text="${post.title}">제목</div>
+
+            <div class="postcard__meta">
+              <span class="meta__item">👁 <b th:text="${post.viewCount}">0</b></span>
+              <span class="meta__dot">·</span>
+              <span class="meta__item">📖 <b th:text="${post.scrapCount}">0</b></span>
+              <span class="meta__dot">·</span>
+              <span class="meta__item">💬 <b th:text="${post.commentCount}">0</b></span>
+            </div>
+
+            <div class="postcard__tags">
+              <span
+                th:each="tag, iterStat : ${post.skillTags}"
+                th:if="${iterStat.index < 6}"
+                class="chip"
+                th:text="${tag}"
+              ></span>
+              <span
+                th:if="${post.skillTags != null && post.skillTags.size() > 6}"
+                class="chip chip--more"
+                th:text="'+' + ${post.skillTags.size() - 6}"
+              ></span>
+            </div>
+          </a>
+        </div>
+      </section>
+
+      <!-- 사이드바 필터 -->
+      <aside class="board-aside">
+        <div class="card side">
+          <div class="side__head">
+            <h2 class="side__title">필터</h2>
+          </div>
+
+          <div class="side__section">
+            <div class="side__label">기술 스택</div>
+            <div class="side__hint">원하는 태그를 선택하세요</div>
+
+            <div class="side__tagbox">
+              <label
+                th:each="tag : ${skillTags}"
+                class="tagcheck"
+              >
+                <input
+                  type="checkbox"
+                  name="tagIds"
+                  th:value="${tag.id}"
+                  th:checked="${param.tagIds != null && #lists.contains(param.tagIds, tag.id.toString())}"
+                  class="tagcheck__input tag-filter"
+                  onchange="applyFilters()"
+                />
+                <span class="tagcheck__box"></span>
+                <span class="tagcheck__text" th:text="${tag.name}"></span>
+              </label>
+            </div>
+          </div>
+        </div>
+      </aside>
+    </div>
+
+    <!-- 페이지네이션 -->
+    <nav th:if="${totalPages > 0}" class="pager" aria-label="페이지네이션">
+      <a
+        th:if="${currentPage > 0}"
+        th:href="@{/board/posts(page=${currentPage - 1}, size=${pageSize}, keyword=${param.keyword}, status=${param.status}, sort=${param.sort}, tagIds=${param.tagIds})}"
+        class="btn btn--ghost"
+      >이전</a>
+      <button th:unless="${currentPage > 0}" class="btn btn--ghost" disabled>이전</button>
+
       <div class="pager__info">
-        <span id="pageInfo">1 / 1</span>
+        <span th:text="${currentPage + 1} + ' / ' + ${totalPages}">1 / 1</span>
       </div>
-      <button id="nextBtn" class="btn btn--ghost" type="button">다음</button>
+
+      <a
+        th:if="${currentPage < totalPages - 1}"
+        th:href="@{/board/posts(page=${currentPage + 1}, size=${pageSize}, keyword=${param.keyword}, status=${param.status}, sort=${param.sort}, tagIds=${param.tagIds})}"
+        class="btn btn--ghost"
+      >다음</a>
+      <button th:unless="${currentPage < totalPages - 1}" class="btn btn--ghost" disabled>다음</button>
     </nav>
   </main>
 
   <script>
-    (function () {
-      const $ = (id) => document.getElementById(id);
+    function applyFilters() {
+      const keyword = document.getElementById('keywordInput').value;
+      const status = document.getElementById('statusSelect').value;
+      const sort = document.getElementById('sortSelect').value;
 
-      const state = {
-        page: 0,
-        size: 12,
-        totalPages: 1,
-        keyword: "",
-        status: "",
-        sort: "LATEST",
-      };
+      const params = new URLSearchParams();
 
-      function fetchJson(url, options) {
-        const base = {
-          credentials: "include",
-          headers: {Accept: "application/json"},
-        };
-        return fetch(url, {...base, ...(options || {})}).then((r) => (r.ok ? r.json() : Promise.reject(r)));
-      }
+      if (keyword) params.append('keyword', keyword);
+      if (status) params.append('status', status);
+      if (sort) params.append('sort', sort);
 
-      function getApiData(res) {
-        return (res && res.data != null) ? res.data : res;
-      }
-
-      function buildQuery() {
-        const params = new URLSearchParams();
-        params.set("page", String(state.page));
-        params.set("size", String(state.size));
-
-        if (state.keyword) params.set("keyword", state.keyword);
-        if (state.status) params.set("status", state.status);
-        if (state.sort) params.set("sort", state.sort);
-
-        return params.toString();
-      }
-
-      function badgeClass(status) {
-        const s = String(status || "").toUpperCase();
-        if (s === "OPEN") return "badge badge--blue";
-        if (s === "CLOSED") return "badge badge--gray";
-        if (s === "DELETED") return "badge badge--red";
-        return "badge badge--gray";
-      }
-
-      function formatDate(value) {
-        if (!value) return "-";
-        const d = new Date(value);
-        if (isNaN(d.getTime())) return String(value);
-        const pad = (n) => String(n).padStart(2, "0");
-        return d.getFullYear() + "-" + pad(d.getMonth() + 1) + "-" + pad(d.getDate());
-      }
-
-      function escapeHtml(s) {
-        return String(s)
-          .replaceAll("&", "&amp;")
-          .replaceAll("<", "&lt;")
-          .replaceAll(">", "&gt;")
-          .replaceAll('"', "&quot;")
-          .replaceAll("'", "&#039;");
-      }
-
-      function renderCards(items) {
-        const list = $("cardList");
-        const empty = $("emptyState");
-        list.innerHTML = "";
-
-        if (!items || items.length === 0) {
-          empty.style.display = "block";
-          return;
-        }
-        empty.style.display = "none";
-
-        items.forEach((p) => {
-          const postId = p.postId ?? p.id;
-          const title = p.title ?? "-";
-          const status = p.postStatus ?? p.status ?? "-";
-          const viewCount = p.viewCount ?? 0;
-          const scrapCount = p.scrapCount ?? 0;
-          const commentCount = p.commentCount ?? 0;
-          const createdAt = formatDate(p.createdAt);
-
-          const tags = Array.isArray(p.skillTags) ? p.skillTags : [];
-          const tagHtml = tags.slice(0, 6).map((t) => {
-            const name = (t && typeof t === "object") ? (t.name ?? t.tagName ?? "") : String(t);
-            if (!name) return "";
-            return `<span class="chip">${escapeHtml(name)}</span>`;
-          }).join("");
-
-          const card = document.createElement("a");
-          card.className = "postcard";
-          card.href = "/board/posts/" + postId;
-
-          card.innerHTML = `
-            <div class="postcard__top">
-              <span class="${badgeClass(status)}">${escapeHtml(String(status).toUpperCase())}</span>
-              <span class="postcard__date">${createdAt}</span>
-            </div>
-            <div class="postcard__title">${escapeHtml(title)}</div>
-            <div class="postcard__meta">
-              <span class="meta__item">👁 <b>${viewCount}</b></span>
-              <span class="meta__dot">·</span>
-              <span class="meta__item">🔖 <b>${scrapCount}</b></span>
-              <span class="meta__dot">·</span>
-              <span class="meta__item">💬 <b>${commentCount}</b></span>
-            </div>
-            <div class="postcard__tags">${tagHtml}</div>
-          `;
-
-          list.appendChild(card);
-        });
-      }
-
-      function updatePager() {
-        $("pageInfo").innerText = String(state.page + 1) + " / " + String(state.totalPages);
-        $("prevBtn").disabled = state.page <= 0;
-        $("nextBtn").disabled = state.page >= state.totalPages - 1;
-      }
-
-      function load() {
-        const url = "/api/board/posts?" + buildQuery();
-        return fetchJson(url)
-          .then((res) => {
-            const data = getApiData(res) || {};
-            const content = data.content ?? data.posts ?? data.items ?? [];
-            const totalPages = data.totalPages ?? data.pageInfo?.totalPages ?? 1;
-
-            state.totalPages = Number(totalPages || 1);
-            renderCards(Array.isArray(content) ? content : []);
-            updatePager();
-          })
-          .catch(async (r) => {
-            // 로그인/정책 위반(예: 401/403/409)으로 목록이 막힌 경우 UI를 비우고 끝냄
-            renderCards([]);
-            state.totalPages = 1;
-            updatePager();
-            try {
-              await r.text();
-            } catch (e) {
-            }
-          });
-      }
-
-      $("applyBtn").addEventListener("click", () => {
-        state.keyword = String($("keyword").value || "").trim();
-        state.status = String($("status").value || "").trim();
-        state.sort = String($("sort").value || "LATEST").trim();
-        state.page = 0;
-        load();
+      // 태그 체크박스 수집
+      document.querySelectorAll('.tag-filter:checked').forEach(cb => {
+        params.append('tagIds', cb.value);
       });
 
-      $("resetBtn").addEventListener("click", () => {
-        $("keyword").value = "";
-        $("status").value = "";
-        $("sort").value = "LATEST";
-
-        state.keyword = "";
-        state.status = "";
-        state.sort = "LATEST";
-        state.page = 0;
-        load();
-      });
-
-      $("prevBtn").addEventListener("click", () => {
-        if (state.page <= 0) return;
-        state.page -= 1;
-        load();
-      });
-
-      $("nextBtn").addEventListener("click", () => {
-        if (state.page >= state.totalPages - 1) return;
-        state.page += 1;
-        load();
-      });
-
-      load();
-    })();
+      // 페이지 이동
+      window.location.href = '/board/posts?' + params.toString();
+    }
   </script>
 </section>
 </body>

--- a/src/main/resources/templates/mypage/mentee/scraps.html
+++ b/src/main/resources/templates/mypage/mentee/scraps.html
@@ -1,94 +1,194 @@
+<!-- src/main/resources/templates/mypage/mentee/scraps.html -->
 <!DOCTYPE html>
-<html lang="ko"
-      xmlns:th="http://www.thymeleaf.org"
-      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
-      layout:decorate="~{common/layout/mentee}">
-
+<html
+  lang="ko"
+  xmlns:th="http://www.thymeleaf.org"
+  xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+  layout:decorate="~{common/layout/mentee}"
+>
 <head>
   <th:block layout:fragment="head">
     <title>DODEUL | 멘티 스크랩</title>
-    <link rel="stylesheet" href="/css/mypage/dashboard.css">
+    <link rel="stylesheet" href="/css/mypage/dashboard.css"/>
+    <style>
+      .tag-chip {
+        display: inline-flex;
+        align-items: center;
+        height: 22px;
+        padding: 0 8px;
+        border-radius: 999px;
+        border: 1px solid rgba(37, 99, 235, 0.18);
+        background: rgba(37, 99, 235, 0.06);
+        color: #2563eb;
+        font-size: 11px;
+        font-weight: 700;
+        white-space: nowrap;
+        margin-right: 4px;
+        margin-bottom: 4px;
+      }
+      .tag-chip--more {
+        border-color: rgba(17, 24, 39, 0.12);
+        background: rgba(17, 24, 39, 0.04);
+        color: rgba(17, 24, 39, 0.7);
+      }
+      .dashboard-row-tags {
+        margin-top: 6px;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0;
+        overflow: hidden;
+      }
+    </style>
   </th:block>
 </head>
 
 <body>
 <div layout:fragment="page">
-
   <div class="dashboard-header">
-    <h2 class="fw-bold" style="margin-bottom:8px;">스크랩</h2>
-    <p class="text-small" style="margin-bottom:16px;">스크랩한 항목을 확인할 수 있습니다.</p>
+    <h2 class="fw-bold" style="margin-bottom: 8px">스크랩</h2>
+    <p class="text-small" style="margin-bottom: 16px">
+      스크랩한 항목을 확인할 수 있습니다.
+    </p>
   </div>
 
   <!-- 필터 -->
-  <section class="card-custom" style="margin-bottom:16px;">
-    <div class="fw-bold" style="margin-bottom:10px;">필터</div>
-    <div style="display:flex; gap:8px; flex-wrap:wrap;">
-      <button class="tag tag--selectable tag--active" type="button" data-filter="all">전체</button>
-      <button class="tag tag--selectable" type="button" data-filter="post">기술 스택</button>
-      <button class="tag tag--selectable" type="button" data-filter="mentor">상담 유형</button>
+  <section class="card-custom" style="margin-bottom: 16px">
+    <div class="fw-bold" style="margin-bottom: 10px">필터</div>
+    <div id="filterContainer" style="display: flex; gap: 8px; flex-wrap: wrap">
+      <button
+        class="tag tag--selectable tag--active"
+        type="button"
+        data-filter="all"
+      >
+        전체
+      </button>
+      <!-- 동적 태그 필터가 여기에 추가됨 -->
     </div>
-    <p class="text-small" style="margin-top:10px;">※ 현재는 UI만 제공되며, 추후 API 연동 예정입니다.</p>
   </section>
 
   <!-- 리스트 -->
   <section>
-    <div class="fw-bold" style="margin-bottom:10px;">스크랩 목록</div>
+    <div class="fw-bold" style="margin-bottom: 10px">스크랩 목록</div>
 
-    <div class="card-custom dashboard-list" id="scrapList" style="margin:0;">
+    <div class="card-custom dashboard-list" id="scrapList" style="margin: 0">
       <div class="dashboard-row">
         <div class="text-small">불러오는 중…</div>
       </div>
     </div>
 
-    <p id="scrapError" style="color:#d33; margin-top:12px;"></p>
+    <p id="scrapError" style="color: #d33; margin-top: 12px"></p>
   </section>
-
 </div>
 
 <th:block layout:fragment="script">
   <script>
     function escapeHtml(s) {
-      return String(s ?? '')
-        .replaceAll('&', '&amp;')
-        .replaceAll('<', '&lt;')
-        .replaceAll('>', '&gt;')
-        .replaceAll('"', '&quot;')
+      return String(s ?? "")
+        .replaceAll("&", "&amp;")
+        .replaceAll("<", "&lt;")
+        .replaceAll(">", "&gt;")
+        .replaceAll('"', "&quot;")
         .replaceAll("'", "&#039;");
     }
 
-    function badgeHtml(type) {
-      if (type === 'post') return '<span class="status-badge status-approved">기술 태그</span>';
-      if (type === 'mentor') return '<span class="status-badge status-review">상담 분야</span>';
-      return '<span class="status-badge status-canceled">-</span>';
-    }
-
     function hrefByItem(item) {
-      // TODO: 실제 상세 링크 확정되면 교체
-      if (item.type === 'post') return '/board/posts';
-      if (item.type === 'mentor') return '/mentors';
-      return '#';
+      if (item.type === "post") return "/board/posts/" + item.id;
+      return "#";
     }
 
-    function render(listEl, items, onUnscrap) {
+    // 태그 레이아웃 조정 (한 줄 넘어가면 +N 처리)
+    function adjustTagLayout() {
+      document.querySelectorAll('.dashboard-row-tags').forEach(container => {
+        const chips = Array.from(container.querySelectorAll('.tag-chip:not(.tag-chip--more)'));
+        if (chips.length === 0) return;
+
+        // 초기화: 모두 표시
+        chips.forEach(c => c.style.display = 'inline-flex');
+        let moreChip = container.querySelector('.tag-chip--more');
+        if (moreChip) moreChip.remove();
+
+        // 줄바꿈 감지
+        const firstTop = chips[0].offsetTop;
+        let hiddenCount = 0;
+        let breakIndex = -1;
+
+        for (let i = 0; i < chips.length; i++) {
+          if (chips[i].offsetTop > firstTop) {
+            breakIndex = i;
+            break;
+          }
+        }
+
+        if (breakIndex !== -1) {
+          // 줄바꿈 발생 시점부터 숨김
+          for (let i = breakIndex; i < chips.length; i++) {
+            chips[i].style.display = 'none';
+            hiddenCount++;
+          }
+
+          // +N 칩 추가
+          if (hiddenCount > 0) {
+            moreChip = document.createElement('span');
+            moreChip.className = 'tag-chip tag-chip--more';
+            moreChip.textContent = '+' + hiddenCount;
+            container.appendChild(moreChip);
+
+            // +N 칩이 줄바꿈되면 하나 더 숨김
+            if (moreChip.offsetTop > firstTop) {
+              moreChip.remove();
+              if (breakIndex > 0) {
+                chips[breakIndex - 1].style.display = 'none';
+                hiddenCount++;
+
+                moreChip = document.createElement('span');
+                moreChip.className = 'tag-chip tag-chip--more';
+                moreChip.textContent = '+' + hiddenCount;
+                container.appendChild(moreChip);
+              }
+            }
+          }
+        }
+      });
+    }
+
+    // 태그 HTML 생성 (모두 렌더링, 이후 JS로 조정)
+    function renderTags(tags, activeTag) {
+      if (!tags || tags.length === 0) return "";
+
+      let displayTags = [...tags];
+
+      // 활성 태그가 있고 목록에 포함되어 있다면 맨 앞으로 이동
+      if (activeTag && activeTag !== 'all' && displayTags.includes(activeTag)) {
+        displayTags = displayTags.filter(t => t !== activeTag);
+        displayTags.unshift(activeTag);
+      }
+
+      return `<div class="dashboard-row-tags">` +
+        displayTags.map(t => `<span class="tag-chip">${escapeHtml(t)}</span>`).join("") +
+        `</div>`;
+    }
+
+    function render(listEl, items, onUnscrap, activeTag) {
       if (!items || items.length === 0) {
         listEl.innerHTML = `<div class="dashboard-row"><div class="text-small">스크랩한 항목이 없습니다.</div></div>`;
         return;
       }
 
-      listEl.innerHTML = items.map(it => {
-        const title = escapeHtml(it.title);
-        const sub = escapeHtml(it.subText ?? '');
-        const badge = badgeHtml(it.type);
-        const href = hrefByItem(it);
+      listEl.innerHTML = items
+        .map((it) => {
+          const title = escapeHtml(it.title);
+          const sub = escapeHtml(it.subText ?? "");
+          const href = hrefByItem(it);
+          const tagsHtml = renderTags(it.tags, activeTag);
 
-        return `
+          return `
           <div class="dashboard-row">
-            <div>
+            <div style="flex: 1; min-width: 0; padding-right: 10px;">
               <div class="dashboard-row-title">${title}</div>
               <div class="dashboard-row-sub">${sub}</div>
+              ${tagsHtml}
             </div>
             <div class="dashboard-row-right">
-              ${badge}
               <a class="btn-outline-custom" style="padding:8px 10px; font-size:12px;" href="${escapeHtml(href)}">보기</a>
               <button class="btn-outline-custom" style="padding:8px 10px; font-size:12px;" type="button"
                       data-unscrap-id="${escapeHtml(it.id)}">
@@ -97,67 +197,137 @@
             </div>
           </div>
         `;
-      }).join('');
+        })
+        .join("");
 
-      // bind events
-      listEl.querySelectorAll('[data-unscrap-id]').forEach(btn => {
-        btn.addEventListener('click', () => {
-          const id = Number(btn.getAttribute('data-unscrap-id'));
+      listEl.querySelectorAll("[data-unscrap-id]").forEach((btn) => {
+        btn.addEventListener("click", () => {
+          const id = Number(btn.getAttribute("data-unscrap-id"));
           onUnscrap(id);
         });
       });
+
+      // 렌더링 후 레이아웃 조정
+      setTimeout(adjustTagLayout, 0);
+    }
+
+    function fetchJson(url, options) {
+      const base = {
+        credentials: "include",
+        headers: {
+          Accept: "application/json",
+          ...(options && options.headers ? options.headers : {}),
+        },
+      };
+      return fetch(url, {...base, ...(options || {})}).then((r) =>
+        r.ok ? r.json() : Promise.reject(r)
+      );
+    }
+
+    function getApiData(res) {
+      if (res && res.data != null) return res.data;
+      return res;
     }
 
     (function () {
-      const listEl = document.getElementById('scrapList');
-      const errEl = document.getElementById('scrapError');
+      const listEl = document.getElementById("scrapList");
+      const errEl = document.getElementById("scrapError");
+      const filterContainer = document.getElementById("filterContainer");
 
-      // TODO: API 연동 예정 (현재 mock)
-      let mock = [
-        {id: 11, type: 'post', title: '기능 정리 글', subText: '게시판 · 2026-01-12'},
-        {id: 12, type: 'post', title: '코드리뷰의 장점', subText: '게시판 · 2026-01-11'},
-        {id: 13, type: 'mentor', title: '면접 준비', subText: '게시판 · 2026-01-11'}
-      ];
-
-      let currentFilter = 'all';
+      let allItems = [];
+      let currentFilter = "all";
 
       function setActive(btn) {
-        document.querySelectorAll('[data-filter]').forEach(b => b.classList.remove('tag--active'));
-        btn.classList.add('tag--active');
+        filterContainer.querySelectorAll(".tag--selectable").forEach((b) => b.classList.remove("tag--active"));
+        btn.classList.add("tag--active");
       }
 
       function filteredItems() {
-        return (currentFilter === 'all') ? mock : mock.filter(x => x.type === currentFilter);
+        if (currentFilter === "all") return allItems;
+        // 태그 필터링
+        return allItems.filter((x) => x.tags && x.tags.includes(currentFilter));
       }
 
       function rerender() {
-        render(listEl, filteredItems(), (id) => {
-          const ok = confirm('스크랩을 해제할까요?');
+        render(listEl, filteredItems(), (postId) => {
+          const ok = confirm("스크랩을 해제할까요?");
           if (!ok) return;
 
-          // TODO: API 연동 시 서버에 delete 요청 후 성공하면 제거
-          mock = mock.filter(x => x.id !== id);
-          rerender();
-        });
+          fetchJson("/api/board/posts/" + postId + "/scrap", {method: "DELETE"})
+            .then(() => load())
+            .catch((err) => {
+              if (err && (err.status === 401 || err.status === 403)) {
+                alert("로그인이 필요합니다.");
+                return;
+              }
+              alert("스크랩 해제에 실패했습니다.");
+            });
+        }, currentFilter);
       }
 
-      document.querySelectorAll('[data-filter]').forEach(btn => {
-        btn.addEventListener('click', () => {
-          currentFilter = btn.getAttribute('data-filter');
-          setActive(btn);
-          rerender();
+      function renderFilters(items) {
+        // 모든 아이템에서 유니크한 태그 추출
+        const allTags = new Set();
+        items.forEach(item => {
+          if (item.tags) {
+            item.tags.forEach(t => allTags.add(t));
+          }
         });
-      });
 
-      try {
-        rerender();
-      } catch (e) {
-        errEl.textContent = '화면을 렌더링할 수 없습니다.';
-        console.error(e);
+        // 기존 필터 버튼 제거 (전체 버튼 제외)
+        const allBtn = filterContainer.querySelector('[data-filter="all"]');
+        filterContainer.innerHTML = '';
+        filterContainer.appendChild(allBtn);
+
+        // 태그 버튼 생성
+        Array.from(allTags).sort().forEach(tag => {
+          const btn = document.createElement('button');
+          btn.className = 'tag tag--selectable';
+          btn.type = 'button';
+          btn.setAttribute('data-filter', tag);
+          btn.textContent = tag;
+          btn.onclick = () => {
+            currentFilter = tag;
+            setActive(btn);
+            rerender();
+          };
+          filterContainer.appendChild(btn);
+        });
+
+        // 전체 버튼 이벤트 재연결
+        allBtn.onclick = () => {
+          currentFilter = 'all';
+          setActive(allBtn);
+          rerender();
+        };
       }
+
+      function load() {
+        errEl.textContent = "";
+        listEl.innerHTML = `<div class="dashboard-row"><div class="text-small">불러오는 중…</div></div>`;
+
+        fetchJson("/api/mypage/scraps", {method: "GET"})
+          .then((res) => {
+            const data = getApiData(res) || {};
+            const items = Array.isArray(data.items) ? data.items : [];
+            allItems = items;
+
+            renderFilters(allItems);
+            rerender();
+          })
+          .catch(() => {
+            errEl.textContent = "스크랩 목록을 불러올 수 없습니다.";
+            allItems = [];
+            rerender();
+          });
+      }
+
+      // 리사이즈 시 태그 레이아웃 재조정
+      window.addEventListener('resize', adjustTagLayout);
+
+      load();
     })();
   </script>
 </th:block>
-
 </body>
 </html>

--- a/src/main/resources/templates/mypage/mentor/scraps.html
+++ b/src/main/resources/templates/mypage/mentor/scraps.html
@@ -1,72 +1,92 @@
+<!-- src/main/resources/templates/mypage/mentor/scraps.html -->
 <!DOCTYPE html>
-<html lang="ko"
-      xmlns:th="http://www.thymeleaf.org"
-      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
-      layout:decorate="~{common/layout/mentor}">
-
+<html
+  lang="ko"
+  xmlns:th="http://www.thymeleaf.org"
+  xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+  layout:decorate="~{common/layout/mentor}"
+>
 <head>
   <th:block layout:fragment="head">
     <title>DODEUL | 멘토 스크랩</title>
-    <link rel="stylesheet" href="/css/mypage/dashboard.css">
+    <link rel="stylesheet" href="/css/mypage/dashboard.css"/>
   </th:block>
 </head>
 
 <body>
 <div layout:fragment="page">
-
   <div class="dashboard-header">
-    <h2 class="fw-bold" style="margin-bottom:8px;">스크랩</h2>
-    <p class="text-small" style="margin-bottom:16px;">스크랩한 항목을 확인할 수 있습니다.</p>
+    <h2 class="fw-bold" style="margin-bottom: 8px">스크랩</h2>
+    <p class="text-small" style="margin-bottom: 16px">
+      스크랩한 항목을 확인할 수 있습니다.
+    </p>
   </div>
 
   <!-- 필터 -->
-  <section class="card-custom" style="margin-bottom:16px;">
-    <div class="fw-bold" style="margin-bottom:10px;">필터</div>
-    <div style="display:flex; gap:8px; flex-wrap:wrap;">
-      <button class="tag tag--selectable tag--active" type="button" data-filter="all">전체</button>
-      <button class="tag tag--selectable" type="button" data-filter="post">기술 스택</button>
-      <button class="tag tag--selectable" type="button" data-filter="mentor">상담 유형</button>
+  <section class="card-custom" style="margin-bottom: 16px">
+    <div class="fw-bold" style="margin-bottom: 10px">필터</div>
+    <div style="display: flex; gap: 8px; flex-wrap: wrap">
+      <button
+        class="tag tag--selectable tag--active"
+        type="button"
+        data-filter="all"
+      >
+        전체
+      </button>
+      <button class="tag tag--selectable" type="button" data-filter="post">
+        기술 스택
+      </button>
+      <button
+        class="tag tag--selectable"
+        type="button"
+        data-filter="mentor"
+        disabled
+        title="게시판 스크랩만 제공됩니다."
+      >
+        상담 유형
+      </button>
     </div>
-    <p class="text-small" style="margin-top:10px;">※ 현재는 UI만 제공되며, 추후 API 연동 예정입니다.</p>
+    <p class="text-small" style="margin-top: 10px">
+      ※ 게시판 스크랩만 API 연동됩니다.
+    </p>
   </section>
 
   <!-- 리스트 -->
   <section>
-    <div class="fw-bold" style="margin-bottom:10px;">스크랩 목록</div>
+    <div class="fw-bold" style="margin-bottom: 10px">스크랩 목록</div>
 
-    <div class="card-custom dashboard-list" id="scrapList" style="margin:0;">
+    <div class="card-custom dashboard-list" id="scrapList" style="margin: 0">
       <div class="dashboard-row">
         <div class="text-small">불러오는 중…</div>
       </div>
     </div>
 
-    <p id="scrapError" style="color:#d33; margin-top:12px;"></p>
+    <p id="scrapError" style="color: #d33; margin-top: 12px"></p>
   </section>
-
 </div>
 
 <th:block layout:fragment="script">
   <script>
     function escapeHtml(s) {
-      return String(s ?? '')
-        .replaceAll('&', '&amp;')
-        .replaceAll('<', '&lt;')
-        .replaceAll('>', '&gt;')
-        .replaceAll('"', '&quot;')
+      return String(s ?? "")
+        .replaceAll("&", "&amp;")
+        .replaceAll("<", "&lt;")
+        .replaceAll(">", "&gt;")
+        .replaceAll('"', "&quot;")
         .replaceAll("'", "&#039;");
     }
 
     function badgeHtml(type) {
-      if (type === 'post') return '<span class="status-badge status-approved">기술 스택</span>';
-      if (type === 'mentor') return '<span class="status-badge status-review">상담 유형</span>';
+      if (type === "post")
+        return '<span class="status-badge status-approved">기술 스택</span>';
+      if (type === "mentor")
+        return '<span class="status-badge status-review">상담 유형</span>';
       return '<span class="status-badge status-canceled">-</span>';
     }
 
     function hrefByItem(item) {
-      // TODO: 실제 상세 링크 확정되면 교체
-      if (item.type === 'post') return '/board/posts';
-      if (item.type === 'mentor') return '/mentors';
-      return '#';
+      if (item.type === "post") return "/board/posts/" + item.id;
+      return "#";
     }
 
     function render(listEl, items, onUnscrap) {
@@ -75,13 +95,14 @@
         return;
       }
 
-      listEl.innerHTML = items.map(it => {
-        const title = escapeHtml(it.title);
-        const sub = escapeHtml(it.subText ?? '');
-        const badge = badgeHtml(it.type);
-        const href = hrefByItem(it);
+      listEl.innerHTML = items
+        .map((it) => {
+          const title = escapeHtml(it.title);
+          const sub = escapeHtml(it.subText ?? "");
+          const badge = badgeHtml(it.type);
+          const href = hrefByItem(it);
 
-        return `
+          return `
           <div class="dashboard-row">
             <div>
               <div class="dashboard-row-title">${title}</div>
@@ -89,7 +110,9 @@
             </div>
             <div class="dashboard-row-right">
               ${badge}
-              <a class="btn-outline-custom" style="padding:8px 10px; font-size:12px;" href="${escapeHtml(href)}">보기</a>
+              <a class="btn-outline-custom" style="padding:8px 10px; font-size:12px;" href="${escapeHtml(
+            href
+          )}">보기</a>
               <button class="btn-outline-custom" style="padding:8px 10px; font-size:12px;" type="button"
                       data-unscrap-id="${escapeHtml(it.id)}">
                 해제
@@ -97,65 +120,100 @@
             </div>
           </div>
         `;
-      }).join('');
+        })
+        .join("");
 
-      listEl.querySelectorAll('[data-unscrap-id]').forEach(btn => {
-        btn.addEventListener('click', () => {
-          const id = Number(btn.getAttribute('data-unscrap-id'));
+      listEl.querySelectorAll("[data-unscrap-id]").forEach((btn) => {
+        btn.addEventListener("click", () => {
+          const id = Number(btn.getAttribute("data-unscrap-id"));
           onUnscrap(id);
         });
       });
     }
 
+    function fetchJson(url, options) {
+      const base = {
+        credentials: "include",
+        headers: {
+          Accept: "application/json",
+          ...(options && options.headers ? options.headers : {}),
+        },
+      };
+      return fetch(url, {...base, ...(options || {})}).then((r) =>
+        r.ok ? r.json() : Promise.reject(r)
+      );
+    }
+
+    function getApiData(res) {
+      if (res && res.data != null) return res.data;
+      return res;
+    }
+
     (function () {
-      const listEl = document.getElementById('scrapList');
-      const errEl = document.getElementById('scrapError');
+      const listEl = document.getElementById("scrapList");
+      const errEl = document.getElementById("scrapError");
 
-      // TODO: API 연동 예정 (현재 mock)
-      let mock = [
-        {id: 1, type: 'post', title: '면접 질문 리스트 정리', subText: '게시판 · 2026-01-12'},
-        {id: 2, type: 'post', title: '문제 해결 경험 공유', subText: '게시판 · 2026-01-10'},
-        {id: 3, type: 'mentor', title: '면접 준비', subText: '게시판 · 2026-01-10'}
-      ];
-
-      let currentFilter = 'all';
+      let allItems = [];
+      let currentFilter = "all";
 
       function setActive(btn) {
-        document.querySelectorAll('[data-filter]').forEach(b => b.classList.remove('tag--active'));
-        btn.classList.add('tag--active');
+        document
+          .querySelectorAll("[data-filter]")
+          .forEach((b) => b.classList.remove("tag--active"));
+        btn.classList.add("tag--active");
       }
 
       function filteredItems() {
-        return (currentFilter === 'all') ? mock : mock.filter(x => x.type === currentFilter);
+        if (currentFilter === "all") return allItems;
+        return allItems.filter((x) => x.type === currentFilter);
       }
 
       function rerender() {
-        render(listEl, filteredItems(), (id) => {
-          const ok = confirm('스크랩을 해제할까요?');
+        render(listEl, filteredItems(), (postId) => {
+          const ok = confirm("스크랩을 해제할까요?");
           if (!ok) return;
 
-          mock = mock.filter(x => x.id !== id);
-          rerender();
+          fetchJson("/api/board/posts/" + postId + "/scrap", {method: "DELETE"})
+            .then(() => load())
+            .catch((err) => {
+              if (err && (err.status === 401 || err.status === 403)) {
+                alert("로그인이 필요합니다.");
+                return;
+              }
+              alert("스크랩 해제에 실패했습니다.");
+            });
         });
       }
 
-      document.querySelectorAll('[data-filter]').forEach(btn => {
-        btn.addEventListener('click', () => {
-          currentFilter = btn.getAttribute('data-filter');
+      function load() {
+        errEl.textContent = "";
+        listEl.innerHTML = `<div class="dashboard-row"><div class="text-small">불러오는 중…</div></div>`;
+
+        fetchJson("/api/mypage/scraps", {method: "GET"})
+          .then((res) => {
+            const data = getApiData(res) || {};
+            const items = Array.isArray(data.items) ? data.items : [];
+            allItems = items;
+            rerender();
+          })
+          .catch(() => {
+            errEl.textContent = "스크랩 목록을 불러올 수 없습니다.";
+            allItems = [];
+            rerender();
+          });
+      }
+
+      document.querySelectorAll("[data-filter]").forEach((btn) => {
+        btn.addEventListener("click", () => {
+          currentFilter = btn.getAttribute("data-filter");
           setActive(btn);
           rerender();
         });
       });
 
-      try {
-        rerender();
-      } catch (e) {
-        errEl.textContent = '화면을 렌더링할 수 없습니다.';
-        console.error(e);
-      }
+      load();
     })();
   </script>
 </th:block>
-
 </body>
 </html>


### PR DESCRIPTION
- 게시글 상세 페이지 UI 개선: 메타 정보 간소화, 버튼 색상 통일, 채택된 댓글 스타일 강조
- 첨부파일 기능 강화: 파일 타입별 아이콘/색상 구분, 미리보기 기능 추가, 작성 시 파일 유지 로직 개선
- 게시글 목록 필터링 개선: 검색/정렬/태그 필터 통합 및 즉시 적용(JS), 조회수순 정렬 추가
- 스크랩 기능 보완: 스크랩 목록 필터링(태그별) 및 반응형 UI 적용, 삭제된 게시글 제외 처리
- 댓글/답글 기능 개선: 작성/수정 시 페이지 리로드 방식 변경(Alert 제거), 인라인 수정 폼 적용

## 관련 이슈
- closed: #165

## 작업 내용
- 공개 게시판(QnA) 게시글에 스크랩(저장) / 스크랩 취소 기능을 추가했습니다.
- 목록/상세에서 스크랩 상태 확인 및 토글이 가능하며, 마이페이지에서 스크랩한 글을 모아볼 수 있도록 했습니다.
- 게시글 목록/상세/작성 화면의 필터링·정렬·첨부파일·댓글/답글 UX를 개선했습니다.

## 체크 리스트
- [x] PR 제목 규칙을 준수했습니다
- [x] 관련 이슈를 연결했습니다
- [x] 본문 내용을 명확하게 작성했습니다
- [x] 정상 작동을 로컬 환경에서 검증했습니다

## 리뷰어에게
- 스크랩 기능과 함께 목록/상세 UI 개선, 첨부파일/댓글 UX 개선이 포함되어 변경 파일이 많습니다.
- 목록 정렬(VIEWS) 추가 및 필터링 로직(JS) 변경이 포함되어 관련 화면 동작을 함께 확인 부탁드립니다.

## 연관 이슈
- #165
