### PR TITLE
[FEAT] 멘토 검색 페이지와 매칭 기능 연동

### DIFF
--- a/src/main/java/org/aibe4/dodeul/domain/consulting/controller/ConsultingApplicationApiController.java
+++ b/src/main/java/org/aibe4/dodeul/domain/consulting/controller/ConsultingApplicationApiController.java
@@ -1,0 +1,55 @@
+package org.aibe4.dodeul.domain.consulting.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aibe4.dodeul.domain.consulting.model.dto.ConsultingApplicationRequest;
+import org.aibe4.dodeul.domain.consulting.service.ConsultingApplicationService;
+import org.aibe4.dodeul.global.response.CommonResponse;
+import org.aibe4.dodeul.global.response.enums.ErrorCode;
+import org.aibe4.dodeul.global.response.enums.SuccessCode;
+import org.aibe4.dodeul.global.security.CustomUserDetails;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/consulting-applications")
+@RequiredArgsConstructor
+public class ConsultingApplicationApiController {
+
+    private final ConsultingApplicationService consultingApplicationService;
+
+    @PostMapping
+    @PreAuthorize("hasRole('MENTEE')")
+    public CommonResponse<Long> saveApplicationApi(
+        @Valid @ModelAttribute ConsultingApplicationRequest request,
+        BindingResult bindingResult,
+        @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        if (bindingResult.hasErrors()) {
+            String errorMessage = bindingResult.getFieldError() != null
+                ? bindingResult.getFieldError().getDefaultMessage()
+                : "입력값이 올바르지 않습니다.";
+            return CommonResponse.fail(ErrorCode.INVALID_INPUT_VALUE, errorMessage);
+        }
+
+        try {
+            request.setMenteeId(user.getMemberId());
+            Long savedId = consultingApplicationService.saveApplication(request);
+
+            return CommonResponse.success(SuccessCode.SUCCESS, savedId);
+
+        } catch (IllegalArgumentException e) {
+            return CommonResponse.fail(ErrorCode.INVALID_INPUT_VALUE, e.getMessage());
+        } catch (Exception e) {
+            log.error("신청서 저장 오류", e);
+            return CommonResponse.fail(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/src/main/java/org/aibe4/dodeul/domain/consulting/controller/ConsultingApplicationController.java
+++ b/src/main/java/org/aibe4/dodeul/domain/consulting/controller/ConsultingApplicationController.java
@@ -6,6 +6,7 @@ import org.aibe4.dodeul.domain.consulting.model.dto.ConsultingApplicationDetailR
 import org.aibe4.dodeul.domain.consulting.model.dto.ConsultingApplicationRequest;
 import org.aibe4.dodeul.domain.consulting.model.enums.ConsultingTag;
 import org.aibe4.dodeul.domain.consulting.service.ConsultingApplicationService;
+import org.aibe4.dodeul.domain.member.service.MemberService;
 import org.aibe4.dodeul.global.security.CustomUserDetails;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
@@ -19,10 +20,19 @@ import org.springframework.web.bind.annotation.*;
 public class ConsultingApplicationController {
 
     private final ConsultingApplicationService consultingApplicationService;
+    private final MemberService memberService;
 
     // 1. 작성 폼
     @GetMapping("/form")
-    public String applicationForm(Model model) {
+    public String applicationForm(
+        @RequestParam(value = "mentorId", required = false) Long mentorId,
+        Model model
+    ) {
+        if (mentorId != null) {
+            model.addAttribute("mentorId", mentorId);
+            String nickname = memberService.getMemberOrThrow(mentorId).getNickname();
+            model.addAttribute("mentorName", nickname);
+        }
         model.addAttribute("request", new ConsultingApplicationRequest());
         model.addAttribute("consultingTags", ConsultingTag.values());
         model.addAttribute("formActionUrl", "/consulting-applications");

--- a/src/main/resources/templates/consulting/application-form.html
+++ b/src/main/resources/templates/consulting/application-form.html
@@ -69,8 +69,8 @@
       </div>
     </div>
 
-    <form th:action="${formActionUrl}" th:object="${request}" method="post" enctype="multipart/form-data">
-
+    <form id="applicationForm" th:action="${formActionUrl}" th:object="${request}" method="post" enctype="multipart/form-data">
+      <input type="hidden" id="targetMentorId" name="mentorId" th:value="${mentorId}">
       <div class="mb-5">
         <h4 class="fw-bold mb-2">카테고리 선택</h4>
         <p class="text-muted small mb-3">관심 있는 멘토링 분야를 1개 선택해주세요.</p>
@@ -144,8 +144,15 @@
         <button type="button" class="btn btn-outline-secondary px-4 py-2" onclick="history.back()">
           < 이전 단계
         </button>
-        <button type="submit" class="btn btn-dark px-4 py-2">
+        <button type="submit" class="btn btn-dark px-4 py-2" th:if="${mentorId == null}">
           멘토 선택 >
+        </button>
+        <button type="button" class="btn btn-dark px-4 py-2"
+                th:if="${mentorId != null}"
+                th:data-mentor-id="${mentorId}"
+                th:data-mentor-name="${mentorName}"
+                onclick="requestMatching(this.dataset.mentorId, this.dataset.mentorName)">
+          상담 신청하기
         </button>
       </div>
     </form>
@@ -295,6 +302,84 @@
       const modalEl = document.getElementById('aiModal');
       const modal = bootstrap.Modal.getInstance(modalEl);
       modal.hide();
+    }
+
+    // 매칭 신청 후 매칭 완료 화면으로 리다이렉트
+    async function requestMatching(mentorId, mentorName) {
+      const safeMentorName = mentorName || '멘토';
+
+      const isConfirmed = await showConfirmModal(`'${safeMentorName}' 멘토님에게 상담을 신청하시겠습니까?`);
+      if (!isConfirmed) return;
+
+      const form = document.getElementById('applicationForm');
+
+      if (!form) {
+        alert("신청서 폼을 찾을 수 없습니다.");
+        return;
+      }
+
+      if (!form.reportValidity()) return;
+
+      const csrfTokenMeta = document.querySelector('meta[name="_csrf"]');
+      const csrfHeaderMeta = document.querySelector('meta[name="_csrf_header"]');
+
+      if (!csrfTokenMeta || !csrfHeaderMeta) {
+        alert('보안 토큰을 찾을 수 없습니다. 페이지를 새로고침 해주세요.');
+        return;
+      }
+
+      const csrfToken = csrfTokenMeta.content;
+      const csrfHeader = csrfHeaderMeta.content;
+
+      try {
+        const formData = new FormData(form);
+
+        const saveResponse = await fetch('/api/consulting-applications', {
+          method: 'POST',
+          headers: {
+            [csrfHeader]: csrfToken
+          },
+          body: formData
+        });
+
+        const saveResult = await saveResponse.json();
+
+        if (!saveResponse.ok || saveResult.code !== 200) {
+          throw new Error(saveResult.message || '신청서 저장에 실패했습니다.');
+        }
+
+        const savedApplicationId = saveResult.data;
+
+        if (!savedApplicationId) {
+          throw new Error('신청서 ID를 받아오지 못했습니다.');
+        }
+
+        const matchingRequestData = {
+          applicationId: savedApplicationId,
+          mentorId: mentorId
+        };
+
+        const matchingResponse = await fetch('/api/matchings', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            [csrfHeader]: csrfToken
+          },
+          body: JSON.stringify(matchingRequestData)
+        });
+
+        const matchingResult = await matchingResponse.json();
+
+        if (matchingResult.code >= 200 && matchingResult.code < 300) {
+          location.href = `/matchings/waiting?mentorName=${encodeURIComponent(safeMentorName)}`;
+        } else {
+          showCommonModal(matchingResult.message || '매칭 신청에 실패했습니다.');
+        }
+
+      } catch (error) {
+        console.error('Request Matching Error:', error);
+        showCommonModal(error.message || '시스템 오류가 발생했습니다.');
+      }
     }
   </script>
 


### PR DESCRIPTION
## 관련 이슈
- closed: #189 

## 작업 내용
- 멘토 검색 페이지에서 상담 신청을 했을 때의 매칭 프로세스를 연동한다

## 체크 리스트
- [x] PR 제목 규칙을 준수했습니다
- [x] 관련 이슈를 연결했습니다
- [x] 본문 내용을 명확하게 작성했습니다
- [ ] 정상 작동을 로컬 환경에서 검증했습니다