### PR TITLE
[FEAT] 멘토 프로필 페이지와 매칭 기능 연동

### DIFF
--- a/src/main/resources/templates/mentor/public-detail.html
+++ b/src/main/resources/templates/mentor/public-detail.html
@@ -34,10 +34,12 @@
 
         <div style="display:flex; flex-direction:column; gap:8px; align-items:flex-end;">
           <!-- 신청서 작성 URL에 맞춰 수정 -->
-          <a class="btn-primary-custom"
-             th:href="@{/consulting-applications/new(mentorId=${mentorId})}">
+          <button class="btn-primary-custom"
+                  th:if="${mentorId != null}"
+                  th:data-mentor-id="${mentorId}"
+                  onclick="checkAvailability(this.dataset.mentorId)">
             신청하기
-          </a>
+          </button>
           <div class="text-small" style="text-align:right;">
             신청서 작성 후 상담 신청이 완료됩니다.
           </div>
@@ -152,6 +154,20 @@
         errEl.textContent = e?.message ?? '프로필을 불러오지 못했습니다.';
       }
     })();
+
+    // 매칭 가능 여부 확인 후 상담신청서 작성 페이지로 리다이렉트
+    function checkAvailability(mentorId) {
+      fetch(`/api/matchings/availability?mentorId=${mentorId}`)
+        .then(response => response.json())
+        .then(data => {
+          if (data.code >= 200 && data.code < 300) {
+            location.href = `/consulting-applications/form?mentorId=${mentorId}`;
+          } else {
+            showCommonModal(data.message || '현재 상담 신청이 불가능합니다.');
+          }
+        })
+        .catch(err => showCommonModal('서버 통신 중 오류가 발생했습니다.'));
+    }
   </script>
 </th:block>
 

--- a/src/main/resources/templates/search/fragments/mentor-card.html
+++ b/src/main/resources/templates/search/fragments/mentor-card.html
@@ -35,7 +35,7 @@
   </div>
 
   <div class="d-grid gap-2 mentor-card-actions">
-    <a th:href="@{/members/{id}(id=${mentor.memberId})}" class="btn-outline-custom mentor-card-btn"
+    <a th:href="@{/mentor/public/{id}(id=${mentor.memberId})}" class="btn-outline-custom mentor-card-btn"
        style="text-decoration: none; text-align: center;">프로필</a>
 
     <button th:if="${mentor.status.name() == 'AVAILABLE'}"


### PR DESCRIPTION
## 관련 이슈
- closed: #196 

## 작업 내용
- 멘토 프로필 페이지에서 상담 신청을 했을 때의 매칭 프로세스를 연동한다

## 체크 리스트
- [x] PR 제목 규칙을 준수했습니다
- [x] 관련 이슈를 연결했습니다
- [x] 본문 내용을 명확하게 작성했습니다
- [x] 정상 작동을 로컬 환경에서 검증했습니다

## 리뷰어에게
- 리팩토링은 추후 진행할 예정입니다