### PR TITLE
[FEAT] 게시판 멘티 멘토 프로필 매칭 기능 연동

### DIFF
--- a/src/main/java/org/aibe4/dodeul/domain/board/controller/BoardPostScrapApiController.java
+++ b/src/main/java/org/aibe4/dodeul/domain/board/controller/BoardPostScrapApiController.java
@@ -6,6 +6,8 @@ import org.aibe4.dodeul.domain.board.model.dto.response.BoardPostScrapStatusResp
 import org.aibe4.dodeul.domain.board.model.dto.response.BoardPostScrapToggleResponse;
 import org.aibe4.dodeul.domain.board.model.dto.response.MyScrapListResponse;
 import org.aibe4.dodeul.domain.board.service.BoardPostScrapService;
+import org.aibe4.dodeul.global.response.CommonResponse;
+import org.aibe4.dodeul.global.response.enums.SuccessCode;
 import org.aibe4.dodeul.global.security.CustomUserDetails;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -18,38 +20,42 @@ public class BoardPostScrapApiController {
     private final BoardPostScrapService boardPostScrapService;
 
     @PostMapping("/board/posts/{postId}/scrap")
-    public BoardPostScrapToggleResponse toggle(
+    public CommonResponse<BoardPostScrapToggleResponse> toggle(
         @AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long postId) {
         Long memberId = userDetails == null ? null : userDetails.getMemberId();
         if (memberId == null) {
             throw new IllegalStateException("로그인이 필요합니다.");
         }
-        return boardPostScrapService.toggle(memberId, postId);
+        BoardPostScrapToggleResponse data = boardPostScrapService.toggle(memberId, postId);
+        return CommonResponse.success(SuccessCode.SUCCESS, data, "스크랩 처리 성공");
     }
 
     @GetMapping("/board/posts/{postId}/scrap")
-    public BoardPostScrapStatusResponse status(
+    public CommonResponse<BoardPostScrapStatusResponse> status(
         @AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long postId) {
         Long memberId = userDetails == null ? null : userDetails.getMemberId();
-        return boardPostScrapService.getStatus(memberId, postId);
+        BoardPostScrapStatusResponse data = boardPostScrapService.getStatus(memberId, postId);
+        return CommonResponse.success(SuccessCode.SUCCESS, data, "스크랩 상태 조회 성공");
     }
 
     @DeleteMapping("/board/posts/{postId}/scrap")
-    public BoardPostScrapToggleResponse delete(
+    public CommonResponse<BoardPostScrapToggleResponse> delete(
         @AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long postId) {
         Long memberId = userDetails == null ? null : userDetails.getMemberId();
         if (memberId == null) {
             throw new IllegalStateException("로그인이 필요합니다.");
         }
-        return boardPostScrapService.delete(memberId, postId);
+        BoardPostScrapToggleResponse data = boardPostScrapService.delete(memberId, postId);
+        return CommonResponse.success(SuccessCode.SUCCESS, data, "스크랩 취소 성공");
     }
 
     @GetMapping("/mypage/scraps")
-    public MyScrapListResponse myScraps(@AuthenticationPrincipal CustomUserDetails userDetails) {
+    public CommonResponse<MyScrapListResponse> myScraps(@AuthenticationPrincipal CustomUserDetails userDetails) {
         Long memberId = userDetails == null ? null : userDetails.getMemberId();
         if (memberId == null) {
             throw new IllegalStateException("로그인이 필요합니다.");
         }
-        return boardPostScrapService.getMyScraps(memberId);
+        MyScrapListResponse data = boardPostScrapService.getMyScraps(memberId);
+        return CommonResponse.success(SuccessCode.SUCCESS, data, "내 스크랩 목록 조회 성공");
     }
 }

--- a/src/main/java/org/aibe4/dodeul/domain/board/model/dto/comment/BoardCommentItemResponse.java
+++ b/src/main/java/org/aibe4/dodeul/domain/board/model/dto/comment/BoardCommentItemResponse.java
@@ -19,6 +19,7 @@ public class BoardCommentItemResponse {
     private String authorDisplayName;
     private String authorNickname;
     private String authorRoleTag;
+    private String authorProfileImageUrl;  // 프로필 이미지 URL
 
     private String content;
     private String commentStatus;

--- a/src/main/resources/static/css/board/post-detail.css
+++ b/src/main/resources/static/css/board/post-detail.css
@@ -424,6 +424,19 @@ body {
   color: var(--muted);
   background: #fafafa;
   flex: 0 0 auto;
+  overflow: hidden;
+}
+
+.comment__avatar--image {
+  padding: 0;
+  background: transparent;
+}
+
+.comment__avatarImg {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 999px;
 }
 
 .comment__meta {
@@ -758,9 +771,11 @@ body {
   background: #fef2f2;
   border-color: rgba(239, 68, 68, 0.2);
 }
+
 .attachcard.type-pdf:hover {
   background: #fee2e2;
 }
+
 .attachcard.type-pdf .attachcard__icon {
   background: #fff;
   color: #ef4444;
@@ -771,9 +786,11 @@ body {
   background: #fff7ed;
   border-color: rgba(249, 115, 22, 0.2);
 }
+
 .attachcard.type-ppt:hover {
   background: #ffedd5;
 }
+
 .attachcard.type-ppt .attachcard__icon {
   background: #fff;
   color: #f97316;
@@ -784,9 +801,11 @@ body {
   background: #eff6ff;
   border-color: rgba(37, 99, 235, 0.2);
 }
+
 .attachcard.type-image:hover {
   background: #dbeafe;
 }
+
 .attachcard.type-image .attachcard__icon {
   background: #fff;
   color: #2563eb;
@@ -797,9 +816,11 @@ body {
   background: #ecfdf5;
   border-color: rgba(22, 163, 74, 0.2);
 }
+
 .attachcard.type-text:hover {
   background: #d1fae5;
 }
+
 .attachcard.type-text .attachcard__icon {
   background: #fff;
   color: #16a34a;

--- a/src/main/resources/templates/board/post-detail.html
+++ b/src/main/resources/templates/board/post-detail.html
@@ -74,12 +74,12 @@
             <span class="meta__value" th:text="${post.consultingTag != null ? post.consultingTag.description : '-'}">-</span>
           </span>
           <span class="meta__date">
-            <span th:text="${#temporals.format(post.createdAt, 'yyyy-MM-dd HH:mm')}">-</span>
-            <span
-              th:if="${post.updatedAt != null && !#temporals.format(post.updatedAt, 'yyyy-MM-dd HH:mm').equals(#temporals.format(post.createdAt, 'yyyy-MM-dd HH:mm'))}"
-              class="meta__updated"
-              th:text="'(수정됨: ' + ${#temporals.format(post.updatedAt, 'yyyy-MM-dd HH:mm')} + ')'"
-            ></span>
+            <!-- 수정되지 않았으면 생성시간만 표시 -->
+            <span th:if="${post.updatedAt == null || #temporals.format(post.updatedAt, 'yyyy-MM-dd HH:mm').equals(#temporals.format(post.createdAt, 'yyyy-MM-dd HH:mm'))}"
+                  th:text="${#temporals.format(post.createdAt, 'yyyy-MM-dd HH:mm')}">-</span>
+            <!-- 수정되었으면 수정시간만 표시 -->
+            <span th:if="${post.updatedAt != null && !#temporals.format(post.updatedAt, 'yyyy-MM-dd HH:mm').equals(#temporals.format(post.createdAt, 'yyyy-MM-dd HH:mm'))}"
+                  th:text="'수정: ' + ${#temporals.format(post.updatedAt, 'yyyy-MM-dd HH:mm')}">-</span>
           </span>
         </div>
 
@@ -190,7 +190,17 @@
           >
             <div class="comment__head">
               <div class="comment__left">
-                <div class="comment__avatar" th:text="${#strings.substring(comment.authorDisplayName, 0, 1).toUpperCase()}">A</div>
+                <!-- 프로필 이미지가 없으면 닉네임 첫 글자 표시 -->
+                <div class="comment__avatar"
+                     th:if="${comment.authorProfileImageUrl == null or comment.authorProfileImageUrl.isEmpty()}"
+                     th:text="${#strings.substring(comment.authorDisplayName, 0, 1).toUpperCase()}">A</div>
+                <!-- 프로필 이미지가 있으면 이미지 표시 -->
+                <div class="comment__avatar comment__avatar--image"
+                     th:if="${comment.authorProfileImageUrl != null and !comment.authorProfileImageUrl.isEmpty()}">
+                  <img th:src="${comment.authorProfileImageUrl}"
+                       th:alt="${comment.authorDisplayName}"
+                       class="comment__avatarImg"/>
+                </div>
                 <div class="comment__meta">
                   <div class="comment__topline">
                     <span class="comment__name" th:text="${comment.authorDisplayName}">익명</span>
@@ -212,12 +222,14 @@
                       style="background:#fef2f2;color:#ef4444;border-color:rgba(239,68,68,0.18)"
                     >멘티</span>
 
-                    <span class="comment__time" th:text="${#temporals.format(comment.createdAt, 'yyyy-MM-dd HH:mm')}">방금 전</span>
-                    <span
-                      th:if="${comment.updatedAt != null && !#temporals.format(comment.updatedAt, 'yyyy-MM-dd HH:mm').equals(#temporals.format(comment.createdAt, 'yyyy-MM-dd HH:mm'))}"
-                      class="comment__time"
-                      th:text="'(수정됨: ' + ${#temporals.format(comment.updatedAt, 'yyyy-MM-dd HH:mm')} + ')'"
-                    ></span>
+                    <!-- 수정되지 않았으면 생성시간만 표시 -->
+                    <span class="comment__time"
+                          th:if="${comment.updatedAt == null || #temporals.format(comment.updatedAt, 'yyyy-MM-dd HH:mm').equals(#temporals.format(comment.createdAt, 'yyyy-MM-dd HH:mm'))}"
+                          th:text="${#temporals.format(comment.createdAt, 'yyyy-MM-dd HH:mm')}">방금 전</span>
+                    <!-- 수정되었으면 수정시간만 표시 -->
+                    <span class="comment__time"
+                          th:if="${comment.updatedAt != null && !#temporals.format(comment.updatedAt, 'yyyy-MM-dd HH:mm').equals(#temporals.format(comment.createdAt, 'yyyy-MM-dd HH:mm'))}"
+                          th:text="'수정: ' + ${#temporals.format(comment.updatedAt, 'yyyy-MM-dd HH:mm')}">방금 전</span>
                   </div>
                 </div>
               </div>
@@ -290,7 +302,18 @@
           >
             <div class="comment__head">
               <div class="comment__left">
-                <div class="comment__avatar" style="width:28px; height:28px; font-size:12px;" th:text="${#strings.substring(child.authorDisplayName, 0, 1).toUpperCase()}">A</div>
+                <!-- 프로필 이미지가 없으면 닉네임 첫 글자 표시 -->
+                <div class="comment__avatar" style="width:28px; height:28px; font-size:12px;"
+                     th:if="${child.authorProfileImageUrl == null or child.authorProfileImageUrl.isEmpty()}"
+                     th:text="${#strings.substring(child.authorDisplayName, 0, 1).toUpperCase()}">A</div>
+                <!-- 프로필 이미지가 있으면 이미지 표시 -->
+                <div class="comment__avatar comment__avatar--image" style="width:28px; height:28px;"
+                     th:if="${child.authorProfileImageUrl != null and !child.authorProfileImageUrl.isEmpty()}">
+                  <img th:src="${child.authorProfileImageUrl}"
+                       th:alt="${child.authorDisplayName}"
+                       class="comment__avatarImg"
+                       style="width:100%; height:100%;"/>
+                </div>
                 <div class="comment__meta">
                   <div class="comment__topline">
                     <span class="comment__name" style="font-size:13px;" th:text="${child.authorDisplayName}">익명</span>
@@ -306,13 +329,14 @@
                       style="background:#ecfdf5;color:#16a34a;border-color:rgba(22,163,74,0.18);font-size:11px;"
                     >멘토</span>
 
-                    <span class="comment__time" style="font-size:11px;" th:text="${#temporals.format(child.createdAt, 'yyyy-MM-dd HH:mm')}">방금 전</span>
-                    <span
-                      th:if="${child.updatedAt != null && !#temporals.format(child.updatedAt, 'yyyy-MM-dd HH:mm').equals(#temporals.format(child.createdAt, 'yyyy-MM-dd HH:mm'))}"
-                      class="comment__time"
-                      style="font-size:11px;"
-                      th:text="'(수정됨: ' + ${#temporals.format(child.updatedAt, 'yyyy-MM-dd HH:mm')} + ')'"
-                    ></span>
+                    <!-- 수정되지 않았으면 생성시간만 표시 -->
+                    <span class="comment__time" style="font-size:11px;"
+                          th:if="${child.updatedAt == null || #temporals.format(child.updatedAt, 'yyyy-MM-dd HH:mm').equals(#temporals.format(child.createdAt, 'yyyy-MM-dd HH:mm'))}"
+                          th:text="${#temporals.format(child.createdAt, 'yyyy-MM-dd HH:mm')}">방금 전</span>
+                    <!-- 수정되었으면 수정시간만 표시 -->
+                    <span class="comment__time" style="font-size:11px;"
+                          th:if="${child.updatedAt != null && !#temporals.format(child.updatedAt, 'yyyy-MM-dd HH:mm').equals(#temporals.format(child.createdAt, 'yyyy-MM-dd HH:mm'))}"
+                          th:text="'수정: ' + ${#temporals.format(child.updatedAt, 'yyyy-MM-dd HH:mm')}">방금 전</span>
                   </div>
                 </div>
               </div>
@@ -434,7 +458,8 @@
       return;
     }
 
-    const isScraped = this.getAttribute('data-scraped') === 'true';
+    const button = this; // this 바인딩 문제 해결
+    const isScraped = button.getAttribute('data-scraped') === 'true';
     const method = isScraped ? 'DELETE' : 'POST';
 
     fetch(`/api/board/posts/${postId}/scrap`, {
@@ -442,19 +467,39 @@
       credentials: 'include',
       headers: {'Content-Type': 'application/json'}
     })
-      .then(r => r.ok ? r.json() : Promise.reject(r))
-      .then(data => {
-        const newScraped = data.data?.scraped || !isScraped;
-        this.setAttribute('data-scraped', newScraped);
-        this.classList.toggle('iconbtn--active', newScraped);
-        this.querySelector('.iconbtn__icon').textContent = newScraped ? '📌' : '🔖';
-
-        const count = parseInt(this.querySelector('.iconbtn__count').textContent) || 0;
-        const newCount = newScraped ? count + 1 : count - 1;
-        this.querySelector('.iconbtn__count').textContent = newCount;
-        document.getElementById('scrapCountDisplay').textContent = newCount;
+      .then(r => {
+        console.log('스크랩 응답 상태:', r.status, r.ok);
+        if (!r.ok) {
+          return r.text().then(text => {
+            console.error('스크랩 실패 응답:', text);
+            throw new Error('HTTP ' + r.status);
+          });
+        }
+        return r.json();
       })
-      .catch(() => alert('스크랩 처리에 실패했습니다.'));
+      .then(response => {
+        console.log('스크랩 전체 응답:', response);
+
+        // CommonResponse 구조: { code, message, data: { postId, scrappedByMe, scrapCount } }
+        const data = response.data;
+
+        if (!data || typeof data.scrappedByMe === 'undefined' || typeof data.scrapCount === 'undefined') {
+          console.error('응답 데이터 구조 오류:', response);
+          throw new Error('Invalid response structure');
+        }
+
+        const newScraped = data.scrappedByMe;
+        const newCount = data.scrapCount;
+
+        button.setAttribute('data-scraped', newScraped);
+        button.classList.toggle('iconbtn--active', newScraped);
+        button.querySelector('.iconbtn__icon').textContent = newScraped ? '📌' : '🔖';
+        button.querySelector('.iconbtn__count').textContent = newCount;
+      })
+      .catch(err => {
+        console.error('스크랩 에러:', err);
+        alert('스크랩 처리에 실패했습니다.');
+      });
   });
 
   // === 댓글 작성 (AJAX) ===

--- a/src/main/resources/templates/mypage/mentee/scraps.html
+++ b/src/main/resources/templates/mypage/mentee/scraps.html
@@ -26,11 +26,13 @@
         margin-right: 4px;
         margin-bottom: 4px;
       }
+
       .tag-chip--more {
         border-color: rgba(17, 24, 39, 0.12);
         background: rgba(17, 24, 39, 0.04);
         color: rgba(17, 24, 39, 0.7);
       }
+
       .dashboard-row-tags {
         margin-top: 6px;
         display: flex;
@@ -278,6 +280,11 @@
         const allBtn = filterContainer.querySelector('[data-filter="all"]');
         filterContainer.innerHTML = '';
         filterContainer.appendChild(allBtn);
+
+        // 태그가 없으면 전체 버튼만 표시
+        if (allTags.size === 0) {
+          return;
+        }
 
         // 태그 버튼 생성
         Array.from(allTags).sort().forEach(tag => {

--- a/src/main/resources/templates/mypage/mentor/scraps.html
+++ b/src/main/resources/templates/mypage/mentor/scraps.html
@@ -10,6 +10,37 @@
   <th:block layout:fragment="head">
     <title>DODEUL | 멘토 스크랩</title>
     <link rel="stylesheet" href="/css/mypage/dashboard.css"/>
+    <style>
+      .tag-chip {
+        display: inline-flex;
+        align-items: center;
+        height: 22px;
+        padding: 0 8px;
+        border-radius: 999px;
+        border: 1px solid rgba(37, 99, 235, 0.18);
+        background: rgba(37, 99, 235, 0.06);
+        color: #2563eb;
+        font-size: 11px;
+        font-weight: 700;
+        white-space: nowrap;
+        margin-right: 4px;
+        margin-bottom: 4px;
+      }
+
+      .tag-chip--more {
+        border-color: rgba(17, 24, 39, 0.12);
+        background: rgba(17, 24, 39, 0.04);
+        color: rgba(17, 24, 39, 0.7);
+      }
+
+      .dashboard-row-tags {
+        margin-top: 6px;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0;
+        overflow: hidden;
+      }
+    </style>
   </th:block>
 </head>
 
@@ -25,7 +56,7 @@
   <!-- 필터 -->
   <section class="card-custom" style="margin-bottom: 16px">
     <div class="fw-bold" style="margin-bottom: 10px">필터</div>
-    <div style="display: flex; gap: 8px; flex-wrap: wrap">
+    <div id="filterContainer" style="display: flex; gap: 8px; flex-wrap: wrap">
       <button
         class="tag tag--selectable tag--active"
         type="button"
@@ -33,22 +64,8 @@
       >
         전체
       </button>
-      <button class="tag tag--selectable" type="button" data-filter="post">
-        기술 스택
-      </button>
-      <button
-        class="tag tag--selectable"
-        type="button"
-        data-filter="mentor"
-        disabled
-        title="게시판 스크랩만 제공됩니다."
-      >
-        상담 유형
-      </button>
+      <!-- 동적 태그 필터가 여기에 추가됨 -->
     </div>
-    <p class="text-small" style="margin-top: 10px">
-      ※ 게시판 스크랩만 API 연동됩니다.
-    </p>
   </section>
 
   <!-- 리스트 -->
@@ -76,20 +93,84 @@
         .replaceAll("'", "&#039;");
     }
 
-    function badgeHtml(type) {
-      if (type === "post")
-        return '<span class="status-badge status-approved">기술 스택</span>';
-      if (type === "mentor")
-        return '<span class="status-badge status-review">상담 유형</span>';
-      return '<span class="status-badge status-canceled">-</span>';
-    }
-
     function hrefByItem(item) {
       if (item.type === "post") return "/board/posts/" + item.id;
       return "#";
     }
 
-    function render(listEl, items, onUnscrap) {
+    // 태그 레이아웃 조정 (한 줄 넘어가면 +N 처리)
+    function adjustTagLayout() {
+      document.querySelectorAll('.dashboard-row-tags').forEach(container => {
+        const chips = Array.from(container.querySelectorAll('.tag-chip:not(.tag-chip--more)'));
+        if (chips.length === 0) return;
+
+        // 초기화: 모두 표시
+        chips.forEach(c => c.style.display = 'inline-flex');
+        let moreChip = container.querySelector('.tag-chip--more');
+        if (moreChip) moreChip.remove();
+
+        // 줄바꿈 감지
+        const firstTop = chips[0].offsetTop;
+        let hiddenCount = 0;
+        let breakIndex = -1;
+
+        for (let i = 0; i < chips.length; i++) {
+          if (chips[i].offsetTop > firstTop) {
+            breakIndex = i;
+            break;
+          }
+        }
+
+        if (breakIndex !== -1) {
+          // 줄바꿈 발생 시점부터 숨김
+          for (let i = breakIndex; i < chips.length; i++) {
+            chips[i].style.display = 'none';
+            hiddenCount++;
+          }
+
+          // +N 칩 추가
+          if (hiddenCount > 0) {
+            moreChip = document.createElement('span');
+            moreChip.className = 'tag-chip tag-chip--more';
+            moreChip.textContent = '+' + hiddenCount;
+            container.appendChild(moreChip);
+
+            // +N 칩이 줄바꿈되면 하나 더 숨김
+            if (moreChip.offsetTop > firstTop) {
+              moreChip.remove();
+              if (breakIndex > 0) {
+                chips[breakIndex - 1].style.display = 'none';
+                hiddenCount++;
+
+                moreChip = document.createElement('span');
+                moreChip.className = 'tag-chip tag-chip--more';
+                moreChip.textContent = '+' + hiddenCount;
+                container.appendChild(moreChip);
+              }
+            }
+          }
+        }
+      });
+    }
+
+    // 태그 HTML 생성 (모두 렌더링, 이후 JS로 조정)
+    function renderTags(tags, activeTag) {
+      if (!tags || tags.length === 0) return "";
+
+      let displayTags = [...tags];
+
+      // 활성 태그가 있고 목록에 포함되어 있다면 맨 앞으로 이동
+      if (activeTag && activeTag !== 'all' && displayTags.includes(activeTag)) {
+        displayTags = displayTags.filter(t => t !== activeTag);
+        displayTags.unshift(activeTag);
+      }
+
+      return `<div class="dashboard-row-tags">` +
+        displayTags.map(t => `<span class="tag-chip">${escapeHtml(t)}</span>`).join("") +
+        `</div>`;
+    }
+
+    function render(listEl, items, onUnscrap, activeTag) {
       if (!items || items.length === 0) {
         listEl.innerHTML = `<div class="dashboard-row"><div class="text-small">스크랩한 항목이 없습니다.</div></div>`;
         return;
@@ -99,20 +180,18 @@
         .map((it) => {
           const title = escapeHtml(it.title);
           const sub = escapeHtml(it.subText ?? "");
-          const badge = badgeHtml(it.type);
           const href = hrefByItem(it);
+          const tagsHtml = renderTags(it.tags, activeTag);
 
           return `
           <div class="dashboard-row">
-            <div>
+            <div style="flex: 1; min-width: 0; padding-right: 10px;">
               <div class="dashboard-row-title">${title}</div>
               <div class="dashboard-row-sub">${sub}</div>
+              ${tagsHtml}
             </div>
             <div class="dashboard-row-right">
-              ${badge}
-              <a class="btn-outline-custom" style="padding:8px 10px; font-size:12px;" href="${escapeHtml(
-            href
-          )}">보기</a>
+              <a class="btn-outline-custom" style="padding:8px 10px; font-size:12px;" href="${escapeHtml(href)}">보기</a>
               <button class="btn-outline-custom" style="padding:8px 10px; font-size:12px;" type="button"
                       data-unscrap-id="${escapeHtml(it.id)}">
                 해제
@@ -129,6 +208,9 @@
           onUnscrap(id);
         });
       });
+
+      // 렌더링 후 레이아웃 조정
+      setTimeout(adjustTagLayout, 0);
     }
 
     function fetchJson(url, options) {
@@ -152,20 +234,20 @@
     (function () {
       const listEl = document.getElementById("scrapList");
       const errEl = document.getElementById("scrapError");
+      const filterContainer = document.getElementById("filterContainer");
 
       let allItems = [];
       let currentFilter = "all";
 
       function setActive(btn) {
-        document
-          .querySelectorAll("[data-filter]")
-          .forEach((b) => b.classList.remove("tag--active"));
+        filterContainer.querySelectorAll(".tag--selectable").forEach((b) => b.classList.remove("tag--active"));
         btn.classList.add("tag--active");
       }
 
       function filteredItems() {
         if (currentFilter === "all") return allItems;
-        return allItems.filter((x) => x.type === currentFilter);
+        // 태그 필터링
+        return allItems.filter((x) => x.tags && x.tags.includes(currentFilter));
       }
 
       function rerender() {
@@ -182,7 +264,49 @@
               }
               alert("스크랩 해제에 실패했습니다.");
             });
+        }, currentFilter);
+      }
+
+      function renderFilters(items) {
+        // 모든 아이템에서 유니크한 태그 추출
+        const allTags = new Set();
+        items.forEach(item => {
+          if (item.tags) {
+            item.tags.forEach(t => allTags.add(t));
+          }
         });
+
+        // 기존 필터 버튼 제거 (전체 버튼 제외)
+        const allBtn = filterContainer.querySelector('[data-filter="all"]');
+        filterContainer.innerHTML = '';
+        filterContainer.appendChild(allBtn);
+
+        // 태그가 없으면 전체 버튼만 표시
+        if (allTags.size === 0) {
+          return;
+        }
+
+        // 태그 버튼 생성
+        Array.from(allTags).sort().forEach(tag => {
+          const btn = document.createElement('button');
+          btn.className = 'tag tag--selectable';
+          btn.type = 'button';
+          btn.setAttribute('data-filter', tag);
+          btn.textContent = tag;
+          btn.onclick = () => {
+            currentFilter = tag;
+            setActive(btn);
+            rerender();
+          };
+          filterContainer.appendChild(btn);
+        });
+
+        // 전체 버튼 이벤트 재연결
+        allBtn.onclick = () => {
+          currentFilter = 'all';
+          setActive(allBtn);
+          rerender();
+        };
       }
 
       function load() {
@@ -194,6 +318,8 @@
             const data = getApiData(res) || {};
             const items = Array.isArray(data.items) ? data.items : [];
             allItems = items;
+
+            renderFilters(allItems);
             rerender();
           })
           .catch(() => {
@@ -203,13 +329,8 @@
           });
       }
 
-      document.querySelectorAll("[data-filter]").forEach((btn) => {
-        btn.addEventListener("click", () => {
-          currentFilter = btn.getAttribute("data-filter");
-          setActive(btn);
-          rerender();
-        });
-      });
+      // 리사이즈 시 태그 레이아웃 재조정
+      window.addEventListener('resize', adjustTagLayout);
 
       load();
     })();


### PR DESCRIPTION
## 관련 이슈
- closed: #198

## 작업 내용

### 1. 댓글 작성자 프로필 이미지 표시
- `BoardCommentItemResponse`에 `authorProfileImageUrl` 필드 추가
- 프로필 이미지가 있으면 이미지 표시, 없으면 닉네임 첫 글자 표시
- 루트 댓글/대댓글 모두 적용

### 2. N+1 문제 해결
- `BoardCommentService.loadProfileImageMap()` 메서드 추가
- 댓글 작성자 ID를 모아서 배치 조회 (`MemberRepository.findAllById()`)
- 프로필 이미지 조회를 한 번의 쿼리로 처리

### 3. 댓글 시간 표시 개선
- 수정하지 않은 댓글: 생성시간만 표시
- 수정한 댓글: "수정: [시간]"만 표시
- 게시글, 루트 댓글, 대댓글 모두 동일하게 적용

### 4. 스크랩 페이지 동적 필터
- 스크랩된 게시글의 스킬 태그를 자동으로 필터 버튼으로 생성
- 태그 클릭 시 즉시 필터링 (페이지 새로고침 없음)
- 멘토/멘티 페이지 모두 적용

### 5. 스크랩 목록 스킬 태그 시각화
- 각 스크랩 항목에 스킬 태그 칩 표시
- 한 줄 넘어가면 "+N" 처리로 깔끔하게 정리
- 활성 필터 태그는 맨 앞으로 이동

### 6. 게시글 수정 페이지 접근 제어 강화
- `BoardPostViewController.editForm()`에 작성자 권한 확인 로직 추가
- 비로그인 사용자: 로그인 페이지로 리다이렉트
- 다른 사용자: 권한 없음 메시지와 함께 상세 페이지로 리다이렉트
- 작성자 본인만 수정 페이지 접근 가능

## 주요 변경 파일
**Backend (3개)**
- `BoardPostScrapApiController.java` - 스크랩 API
- `BoardPostViewController.java` - 수정 페이지 접근 제어
- `BoardCommentService.java` - 프로필 이미지 배치 조회
- `BoardCommentItemResponse.java` - 프로필 이미지 필드 추가

**Frontend (5개)**
- `post-detail.html` - 프로필 이미지 + 시간 표시 개선
- `post-detail.css` - 프로필 이미지 스타일
- `scraps.html` (멘토) - 동적 필터 + 태그 시각화
- `scraps.html` (멘티) - 동적 필터 + 태그 시각화

## 체크 리스트
- [x] PR 제목 규칙을 준수했습니다
- [x] 관련 이슈를 연결했습니다
- [x] 본문 내용을 명확하게 작성했습니다
- [x] 정상 작동을 로컬 환경에서 검증했습니다

## 연관 이슈
- #198