### PR TITLE
[FEAT] 상담 내역 페이지에서 리뷰 작성 기능 연동

### DIFF
--- a/src/main/resources/templates/common/layout/mentee.html
+++ b/src/main/resources/templates/common/layout/mentee.html
@@ -19,5 +19,7 @@
   <div th:replace="~{common/fragments/footer :: footerSimple()}"></div>
 </div>
 
+<th:block th:replace="~{common/fragments/modal-alert :: alertModal}"></th:block>
+
 </body>
 </html>

--- a/src/main/resources/templates/common/layout/mentor.html
+++ b/src/main/resources/templates/common/layout/mentor.html
@@ -19,5 +19,7 @@
   <div th:replace="~{common/fragments/footer :: footerSimple()}"></div>
 </div>
 
+<th:block th:replace="~{common/fragments/modal-alert :: alertModal}"></th:block>
+
 </body>
 </html>

--- a/src/main/resources/templates/mypage/mentee/sessions.html
+++ b/src/main/resources/templates/mypage/mentee/sessions.html
@@ -195,7 +195,7 @@
                     type="button"
                     data-complete-btn="true"
                     data-matching-id="${escapeHtml(it.matchingId)}">
-              리뷰 작성(완료)
+              리뷰 작성
             </button>
           `
           : '';
@@ -223,21 +223,27 @@
           const id = Number(btn.getAttribute('data-matching-id'));
           if (!id) return;
 
-          const ok = confirm('신청을 취소할까요?');
-          if (!ok) return;
+          const isConfirmed = await showConfirmModal(`신청을 취소할까요?`);
+
+          if (!isConfirmed) {
+            return;
+          }
 
           await onCancel(id);
         });
       });
 
-      // 리뷰 작성 완료
+      // 리뷰 작성
       listEl.querySelectorAll('[data-complete-btn="true"]').forEach(btn => {
         btn.addEventListener('click', async () => {
           const id = Number(btn.getAttribute('data-matching-id'));
           if (!id) return;
 
-          const ok = confirm('리뷰 작성 완료 처리할까요?');
-          if (!ok) return;
+          const isConfirmed = await showConfirmModal(`리뷰를 작성하러 가시겠습니까?`);
+
+          if (!isConfirmed) {
+            return;
+          }
 
           await onComplete(id);
         });
@@ -293,14 +299,7 @@
       }
 
       async function completeMatching(matchingId) {
-        try {
-          errEl.textContent = '';
-          await apiRequest(`/api/matchings/${matchingId}/completion`, {method: 'POST'});
-          await load();
-        } catch (e) {
-          console.error(e);
-          errEl.textContent = e?.message ?? '완료 처리에 실패했습니다.';
-        }
+        window.location.href = `/reviews/new/${matchingId}`;
       }
 
       document.querySelectorAll('[data-filter]').forEach(btn => {

--- a/src/main/resources/templates/mypage/mentor/sessions.html
+++ b/src/main/resources/templates/mypage/mentor/sessions.html
@@ -228,8 +228,11 @@
           const id = Number(btn.getAttribute('data-matching-id'));
           if (!id) return;
 
-          const ok = confirm('이 상담을 수락할까요?');
-          if (!ok) return;
+          const isConfirmed = await showConfirmModal(`이 상담을 수락할까요?`);
+
+          if (!isConfirmed) {
+            return;
+          }
 
           await onAccept(id);
         });
@@ -241,8 +244,11 @@
           const id = Number(btn.getAttribute('data-matching-id'));
           if (!id) return;
 
-          const ok = confirm('이 상담을 거절할까요?');
-          if (!ok) return;
+          const isConfirmed = await showConfirmModal(`이 상담을 거절할까요?`);
+
+          if (!isConfirmed) {
+            return;
+          }
 
           await onReject(id);
         });


### PR DESCRIPTION
## 관련 이슈
- closed: #218 

## 작업 내용
- 멘티의 상담 내역 페이지에서 리뷰 작성 버튼을 클릭하면 리뷰 작성 페이지로 이동한다.
- confirm을 공통 모달창으로 수정한다.

## 체크 리스트
- [x] PR 제목 규칙을 준수했습니다
- [x] 관련 이슈를 연결했습니다
- [x] 본문 내용을 명확하게 작성했습니다
- [x] 정상 작동을 로컬 환경에서 검증했습니다