### PR TITLE
[BUG] 새로운 멘토가 가입하면 멘토 검색 페이지에서 멘토 목록이 안 뜨는 버그

### DIFF
--- a/src/main/java/org/aibe4/dodeul/domain/member/model/entity/MentorProfile.java
+++ b/src/main/java/org/aibe4/dodeul/domain/member/model/entity/MentorProfile.java
@@ -61,6 +61,7 @@ public class MentorProfile implements Profile {
     public static MentorProfile create(Member member) {
         MentorProfile profile = new MentorProfile();
         profile.member = member;
+        profile.careerYears = 0;
 
         // 기본적으로 상담 신청을 받는 상태(ON)
         profile.consultationEnabled = true;


### PR DESCRIPTION
## 관련 이슈
- closed: #219 

## 작업 내용
- 새로운 멘토가 가입했을 때 멘토 프로필 생성 시 연차(careerYears)를 0으로 초기화

## 체크 리스트
- [x] PR 제목 규칙을 준수했습니다
- [x] 관련 이슈를 연결했습니다
- [x] 본문 내용을 명확하게 작성했습니다
- [x] 정상 작동을 로컬 환경에서 검증했습니다