### PR TITLE
[FIX] 상담 신청서 조회 링크 오류

### DIFF
--- a/src/main/java/org/aibe4/dodeul/domain/consulting/controller/ConsultingApplicationController.java
+++ b/src/main/java/org/aibe4/dodeul/domain/consulting/controller/ConsultingApplicationController.java
@@ -151,4 +151,48 @@ public class ConsultingApplicationController {
         consultingApplicationService.deleteApplication(applicationId, user.getMemberId());
         return "redirect:/";
     }
+
+    @GetMapping("/matching/{matchingId}")
+    public String getApplicationDetailByMatching(
+        @PathVariable Long matchingId,
+        @AuthenticationPrincipal CustomUserDetails user,
+        Model model
+    ) {
+        if (user == null) {
+            throw new IllegalStateException("로그인이 필요합니다.");
+        }
+
+        Long applicationId =
+            consultingApplicationService.findApplicationIdByMatchingForMentee(
+                matchingId,
+                user.getMemberId()
+            );
+
+        ConsultingApplicationDetailResponse response =
+            consultingApplicationService.getApplicationDetail(applicationId);
+
+        model.addAttribute("appDetail", response);
+        return "consulting/application-detail";
+    }
+
+    @GetMapping("/matching/{matchingId}/mentor-view")
+    public String getApplicationDetailByMatchingForMentor(
+        @PathVariable Long matchingId,
+        @AuthenticationPrincipal CustomUserDetails user,
+        Model model
+    ) {
+        if (user == null) throw new IllegalStateException("로그인이 필요합니다.");
+
+        Long applicationId =
+            consultingApplicationService.findApplicationIdByMatchingForMentor(
+                matchingId,
+                user.getMemberId()
+            );
+
+        ConsultingApplicationDetailResponse response =
+            consultingApplicationService.getApplicationDetail(applicationId);
+
+        model.addAttribute("appDetail", response);
+        return "consulting/application-mento-detail";
+    }
 }

--- a/src/main/resources/templates/mypage/mentee/sessions.html
+++ b/src/main/resources/templates/mypage/mentee/sessions.html
@@ -112,11 +112,11 @@
     }
 
     function roomHref(matchingId) {
-      return `/consultations/room/${matchingId}`;
+      return `/consultations/matching/${matchingId}`;
     }
 
     function applicationHref(matchingId) {
-      return `/consulting-applications/${matchingId}`;
+      return `/consulting-applications/matching/${matchingId}`;
     }
 
     function canCancel(uiStatus) {

--- a/src/main/resources/templates/mypage/mentor/sessions.html
+++ b/src/main/resources/templates/mypage/mentor/sessions.html
@@ -115,8 +115,8 @@
       return `/consultations/matching/${matchingId}`;
     }
 
-    function applicationHref(matchingId, applicationId) {
-      return `/consulting-applications/${applicationId}/mentor-view`;
+    function applicationHref(matchingId) {
+      return `/consulting-applications/matching/${matchingId}/mentor-view`;
     }
 
 
@@ -173,7 +173,7 @@
         const applicationBtn = `
           <a class="btn-outline-custom"
              style="padding:8px 10px; font-size:12px;"
-             href="${escapeHtml(applicationHref(it.matchingId, it.applicationId))}"
+             href="${escapeHtml(applicationHref(it.matchingId))}"
              data-application-btn="true"
              data-matching-id="${escapeHtml(it.matchingId)}">
             신청서 조회


### PR DESCRIPTION
## 관련 이슈
- closed: #224 

## 작업 내용

- 상담 내역에서 신청서 조회 시 잘못된 URL(applicationId undefined / 잘못된 신청서 노출) 문제 수정
- matchingId → applicationId 변환 로직 명확화
- 멘티: matchingId → applicationId 조회 후 신청서 상세로 이동
- 멘토: 멘토 권한 검증 후 matchingId → applicationId 조회하여 멘토 전용 상세 페이지로 이동

프론트엔드 신청서 조회 링크에서 undefined 발생하던 문제 수정

## 체크 리스트
- [ ] PR 제목 규칙을 준수했습니다
- [ ] 관련 이슈를 연결했습니다
- [ ] 본문 내용을 명확하게 작성했습니다
- [ ] 정상 작동을 로컬 환경에서 검증했습니다
