### PR TITLE
[FIX] 상세 페이지 파일 경로 노출 버그 수정

### DIFF
--- a/src/main/java/org/aibe4/dodeul/domain/consulting/controller/AiConsultingController.java
+++ b/src/main/java/org/aibe4/dodeul/domain/consulting/controller/AiConsultingController.java
@@ -1,5 +1,6 @@
 package org.aibe4.dodeul.domain.consulting.controller;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.aibe4.dodeul.domain.consulting.service.AiConsultingService;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -12,6 +13,7 @@ import java.util.Map;
 @RestController
 @RequestMapping("/api/ai")
 @RequiredArgsConstructor
+@Tag(name = "Consulting", description = "상담 관련 API (AI 초안 및 신청서)")
 public class AiConsultingController {
 
     private final AiConsultingService aiConsultingService;

--- a/src/main/java/org/aibe4/dodeul/domain/consulting/controller/ConsultingApplicationApiController.java
+++ b/src/main/java/org/aibe4/dodeul/domain/consulting/controller/ConsultingApplicationApiController.java
@@ -1,5 +1,6 @@
 package org.aibe4.dodeul.domain.consulting.controller;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,6 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/consulting-applications")
 @RequiredArgsConstructor
+@Tag(name = "Consulting", description = "상담 관련 API (AI 초안 및 신청서)") // 이 줄을 추가하세요
 public class ConsultingApplicationApiController {
 
     private final ConsultingApplicationService consultingApplicationService;

--- a/src/main/resources/templates/consulting/application-detail.html
+++ b/src/main/resources/templates/consulting/application-detail.html
@@ -64,15 +64,15 @@
              th:href="${appDetail.fileUrl}"
              class="text-decoration-none text-dark fw-bold"
              download>
-    <span
-      th:text="${#strings.contains(appDetail.fileUrl, '/') ? #strings.substringAfter(appDetail.fileUrl, '/') : appDetail.fileUrl}">
-        파일명.png
-    </span>
+        <span th:with="fileUrl=${appDetail.fileUrl}, lastIdx=${fileUrl.lastIndexOf('/')}"
+              th:text="${lastIdx != -1 ? fileUrl.substring(lastIdx + 1) : fileUrl}">
+            파일명.png
+        </span>
           </a>
 
           <span th:if="${appDetail.fileUrl == null or appDetail.fileUrl.isEmpty()}" class="text-muted small">
-     첨부된 파일이 없습니다.
-  </span>
+        첨부된 파일이 없습니다.
+    </span>
         </div>
 
       </div>


### PR DESCRIPTION
-상세 조회 시 전체 URL이 노출되던 문제를 lastIndexOf를 활용해 파일명만 출력되도록 수정

#233

## 관련 이슈
- closed: #233

## 작업 내용
-상세 조회 시 전체 URL이 노출되던 문제를 lastIndexOf를 활용해 파일명만 출력되도록 수정

## 체크 리스트
- [x] PR 제목 규칙을 준수했습니다
- [x] 관련 이슈를 연결했습니다
- [x] 본문 내용을 명확하게 작성했습니다
- [x] 정상 작동을 로컬 환경에서 검증했습니다
