### PR TITLE
[REFACTOR] 이니셜 프로필 적용

### DIFF
--- a/src/main/resources/static/css/global.css
+++ b/src/main/resources/static/css/global.css
@@ -443,3 +443,22 @@ footer {
 .status-timeout { background-color: #e9ecef; color: #495057; }
 .status-review { background-color: #e0cffc; color: #59359a; }
 .status-completed { background-color: #d1e7dd; color: #0f5132; }
+
+/* 멘토카드 이니셜 아바타 스타일 (추가) */
+.mentor-card-avatar--initial {
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 24px;
+  object-fit: unset;
+  text-align: center;
+  line-height: 1;
+}
+
+/* 이미지가 있는 경우의 기본 스타일 유지 */
+.mentor-card-avatar:not(.mentor-card-avatar--initial) {
+  object-fit: cover;
+}

--- a/src/main/resources/templates/common/fragments/header.html
+++ b/src/main/resources/templates/common/fragments/header.html
@@ -26,11 +26,17 @@
       <div sec:authorize="isAuthenticated()"
            style="display:flex; align-items:center; gap:12px;">
 
-        <!-- 프로필 아이콘: JS가 src를 교체할 수 있도록 id 부여 -->
+        <!-- 프로필 이미지 (기본은 숨김) -->
         <img id="headerProfileImg"
-             th:src="@{/css/icons/usericon.svg}"
+             src=""
              alt="profile"
-             style="width:32px; height:32px; border-radius:50%; background:#f2f2f2; padding:4px; object-fit:cover;"/>
+             style="width:32px; height:32px; border-radius:50%; object-fit:cover; display:none;"/>
+
+        <!-- 이니셜 아바타 (기본 표시) -->
+        <div id="headerProfileInitial"
+             style="width:32px; height:32px; border-radius:50%; background:linear-gradient(135deg, #667eea 0%, #764ba2 100%); color:white; display:flex; align-items:center; justify-content:center; font-weight:600; font-size:14px;">
+          U
+        </div>
 
         <!-- role을 JS가 읽도록 숨김 값으로 렌더 -->
         <span id="headerUserRole" sec:authentication="principal.role" style="display:none;">ROLE</span>
@@ -62,20 +68,17 @@
       try {
         const nameEl = document.getElementById('headerNickname');
         const imgEl = document.getElementById('headerProfileImg');
+        const initialEl = document.getElementById('headerProfileInitial');
         const roleEl = document.getElementById('headerUserRole');
 
-        // 1) 닉네임은 dashboard에서 최신값 가져오기
-        const dashRes = await fetch('/api/mypage/dashboard', {
-          credentials: 'same-origin',
-          headers: {'accept': 'application/json'}
-        });
-        const dashJson = await dashRes.json().catch(() => null);
-        if (dashRes.ok && nameEl && dashJson?.data?.nickname) {
-          nameEl.textContent = dashJson.data.nickname;
+        // 1) 즉시 렌더링된 닉네임 사용 (페이지 로드와 동시에 표시)
+        let nickname = (nameEl?.textContent || 'U').trim();
+        if (initialEl) {
+          initialEl.textContent = nickname.substring(0, 1).toUpperCase();
         }
 
-        // 2) 프로필 이미지 업데이트는 role 기반으로 유지
-        if (!roleEl || !imgEl) return;
+        // 2) 프로필 이미지는 비동기로 로드
+        if (!roleEl || !imgEl || !initialEl) return;
         let role = (roleEl.textContent || '').trim();
         if (role.startsWith('ROLE_')) role = role.replace('ROLE_', '');
 
@@ -84,21 +87,34 @@
         else if (role === 'MENTEE') url = '/api/mypage/mentee/profile';
         else return;
 
+        // 프로필 정보 가져오기 (닉네임 + 이미지)
         const res = await fetch(url, {credentials: 'same-origin', headers: {'accept': 'application/json'}});
         const json = await res.json().catch(() => null);
-        if (!res.ok) return;
 
-        const profileUrl = json?.data?.profileUrl;
-        if (!profileUrl) return;
+        if (res.ok && json?.data) {
+          // 최신 닉네임으로 업데이트
+          if (json.data.nickname) {
+            nickname = json.data.nickname;
+            if (nameEl) nameEl.textContent = nickname;
+            if (initialEl) initialEl.textContent = nickname.substring(0, 1).toUpperCase();
+          }
 
-        const cacheBusted = profileUrl + (profileUrl.includes('?') ? '&' : '?') + 't=' + Date.now();
-        imgEl.src = cacheBusted;
-        imgEl.style.padding = '0px';
-        imgEl.style.background = 'none';
-        imgEl.style.objectFit = 'cover';
+          // 프로필 이미지 처리
+          const profileUrl = json.data.profileUrl;
+
+          if (profileUrl) {
+            // 이미지가 있으면 이미지 표시
+            const cacheBusted = profileUrl + (profileUrl.includes('?') ? '&' : '?') + 't=' + Date.now();
+            imgEl.src = cacheBusted;
+            imgEl.style.display = 'block';
+            initialEl.style.display = 'none';
+          }
+          // 이미지가 없으면 이미 표시된 이니셜 유지
+        }
 
       } catch (e) {
         console.debug('header sync failed', e);
+        // 에러 시에도 이미 표시된 이니셜 유지
       }
     })();
   </script>

--- a/src/main/resources/templates/consultation/consultation-room.html
+++ b/src/main/resources/templates/consultation/consultation-room.html
@@ -51,6 +51,21 @@
     #fileListContainer::-webkit-scrollbar-track {
       background-color: transparent;
     }
+
+    /* 이니셜 아바타 스타일 */
+    .chat-avatar-initial {
+      width: 40px;
+      height: 40px;
+      border-radius: 50%;
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      color: white;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-weight: 600;
+      font-size: 16px;
+      border: 1px solid var(--color-border);
+    }
   </style>
 </head>
 
@@ -72,12 +87,16 @@
           <div class="chat-header">
             <div class="d-flex align-items-center">
               <div class="me-3">
+                <!-- 프로필 이미지가 없으면 닉네임 첫 글자 표시 -->
+                <div th:if="${opponent.profileUrl == null or #strings.isEmpty(opponent.profileUrl)}"
+                     class="chat-avatar-initial"
+                     th:text="${#strings.substring(opponent.nickname, 0, 1).toUpperCase()}">A</div>
+                <!-- 프로필 이미지가 있으면 이미지 표시 -->
                 <img th:if="${opponent.profileUrl != null and !#strings.isEmpty(opponent.profileUrl)}"
-                     th:src="${opponent.profileUrl}" class="rounded-circle" style="width: 40px; height: 40px; border: 1px solid var(--color-border); object-fit: cover;">
-                <div th:unless="${opponent.profileUrl != null and !#strings.isEmpty(opponent.profileUrl)}"
-                     class="bg-light rounded-circle d-flex align-items-center justify-content-center border" style="width: 40px; height: 40px;">
-                  <i class="bi bi-person-fill text-secondary fs-5"></i>
-                </div>
+                     th:src="${opponent.profileUrl}"
+                     th:alt="${opponent.nickname}"
+                     class="rounded-circle"
+                     style="width: 40px; height: 40px; border: 1px solid var(--color-border); object-fit: cover;">
               </div>
               <div class="d-flex align-items-center">
                 <div class="fw-bold me-2" th:text="${opponent.nickname}">닉네임</div>

--- a/src/main/resources/templates/mypage/mentee/dashboard.html
+++ b/src/main/resources/templates/mypage/mentee/dashboard.html
@@ -14,6 +14,18 @@
         background-position: center;
         background-repeat: no-repeat;
       }
+
+      /* 이니셜 아바타 스타일 */
+      #profileAvatar.avatar-initial {
+        background: linear-gradient(135deg, #667eea 0%, #764ba2 100%) !important;
+        color: white !important;
+        display: flex !important;
+        align-items: center !important;
+        justify-content: center !important;
+        font-weight: 600 !important;
+        font-size: 32px !important;
+        line-height: 1 !important;
+      }
     </style>
   </th:block>
 </head>
@@ -147,15 +159,21 @@
         .replaceAll("'", "&#039;");
     }
 
-    function setAvatar(url) {
+    function setAvatar(url, nickname) {
       const el = document.getElementById('profileAvatar');
       if (!el) return;
 
       if (url) {
+        // 이미지가 있는 경우
         const cacheBusted = url + (url.includes('?') ? '&' : '?') + 't=' + Date.now();
         el.style.backgroundImage = `url(${cacheBusted})`;
+        el.classList.remove('avatar-initial');
+        el.textContent = '';
       } else {
+        // 이미지가 없는 경우 - 이니셜 표시
         el.style.backgroundImage = 'none';
+        el.classList.add('avatar-initial');
+        el.textContent = nickname ? nickname.substring(0, 1).toUpperCase() : 'U';
       }
     }
 
@@ -229,13 +247,15 @@
         const profileJson = await profileRes.json().catch(() => null);
         if (profileRes.ok) {
           const p = profileJson?.data || {};
+          const nickname = p.nickname || '멘티';
           document.getElementById('menteeName').textContent = p.nickname ? `${p.nickname} 멘티` : '멘티';
 
           const job = p.job ?? '-';
           const fields = (p.consultingTags && p.consultingTags.length) ? p.consultingTags.join(', ') : '-';
           document.getElementById('menteeDesc').textContent = `${job} / ${fields}`;
 
-          setAvatar(p.profileUrl);
+          // 프로필 이미지 또는 이니셜 설정
+          setAvatar(p.profileUrl, nickname);
         }
       } catch (e) {
         console.error(e);

--- a/src/main/resources/templates/mypage/mentee/profile-edit.html
+++ b/src/main/resources/templates/mypage/mentee/profile-edit.html
@@ -24,6 +24,18 @@
       .upload-status {
         font-size: 12px;
       }
+
+      /* 이니셜 아바타 스타일 */
+      #profileAvatar.avatar-initial {
+        background: linear-gradient(135deg, #667eea 0%, #764ba2 100%) !important;
+        color: white !important;
+        display: flex !important;
+        align-items: center !important;
+        justify-content: center !important;
+        font-weight: 600 !important;
+        font-size: 32px !important;
+        line-height: 1 !important;
+      }
     </style>
   </th:block>
 </head>
@@ -137,16 +149,22 @@
         .filter(Boolean);
     }
 
-    function setAvatar(url) {
+    function setAvatar(url, nickname) {
       const avatar = document.getElementById('profileAvatar');
       if (!avatar) return;
 
       if (url) {
+        // 이미지가 있는 경우
         avatar.style.backgroundImage = `url(${url})`;
         avatar.style.backgroundSize = 'cover';
         avatar.style.backgroundPosition = 'center';
+        avatar.classList.remove('avatar-initial');
+        avatar.textContent = '';
       } else {
+        // 이미지가 없는 경우 - 이니셜 표시
         avatar.style.backgroundImage = 'none';
+        avatar.classList.add('avatar-initial');
+        avatar.textContent = nickname ? nickname.substring(0, 1).toUpperCase() : 'U';
       }
     }
 
@@ -181,7 +199,8 @@
         }
 
         const url = json?.data;
-        setAvatar(url);
+        const nickname = document.getElementById('menteeName').textContent.replace(' 멘티', '');
+        setAvatar(url, nickname);
         status.textContent = '업로드 완료';
 
       } catch (err) {
@@ -205,6 +224,7 @@
         }
 
         const data = json?.data || {};
+        const nickname = data.nickname || '멘티';
         document.getElementById('menteeName').textContent = data.nickname ? `${data.nickname} 멘티` : '멘티';
 
         const desiredJob = data.job ?? '-';
@@ -213,7 +233,7 @@
           : '-';
         document.getElementById('menteeMeta').textContent = `희망 직무: ${desiredJob} · 관심 상담 분야: ${interests}`;
 
-        setAvatar(data.profileUrl);
+        setAvatar(data.profileUrl, nickname);
 
         document.getElementById('desiredJobInput').value = data.job ?? '';
         document.getElementById('bioInput').value = data.intro ?? '';

--- a/src/main/resources/templates/mypage/mentee/profile.html
+++ b/src/main/resources/templates/mypage/mentee/profile.html
@@ -14,6 +14,18 @@
         background-position: center;
         background-repeat: no-repeat;
       }
+
+      /* 이니셜 아바타 스타일 */
+      #profileAvatar.avatar-initial {
+        background: linear-gradient(135deg, #667eea 0%, #764ba2 100%) !important;
+        color: white !important;
+        display: flex !important;
+        align-items: center !important;
+        justify-content: center !important;
+        font-weight: 600 !important;
+        font-size: 32px !important;
+        line-height: 1 !important;
+      }
     </style>
   </th:block>
 </head>
@@ -82,15 +94,21 @@
       root.innerHTML = arr.map(t => `<span class="tag tag--read-only">${escapeHtml(t)}</span>`).join('');
     }
 
-    function setAvatar(url) {
+    function setAvatar(url, nickname) {
       const el = document.getElementById('profileAvatar');
       if (!el) return;
 
       if (url) {
+        // 이미지가 있는 경우
         const cacheBusted = url + (url.includes('?') ? '&' : '?') + 't=' + Date.now();
         el.style.backgroundImage = `url(${cacheBusted})`;
+        el.classList.remove('avatar-initial');
+        el.textContent = '';
       } else {
+        // 이미지가 없는 경우 - 이니셜 표시
         el.style.backgroundImage = 'none';
+        el.classList.add('avatar-initial');
+        el.textContent = nickname ? nickname.substring(0, 1).toUpperCase() : 'U';
       }
     }
 
@@ -106,6 +124,7 @@
         }
 
         const data = json?.data || {};
+        const nickname = data.nickname || '멘티';
         document.getElementById('menteeName').textContent = data.nickname ? `${data.nickname} 멘티` : '멘티';
 
         const desiredJob = data.job ?? '-';
@@ -122,7 +141,7 @@
         renderTags(document.getElementById('menteeSkills'), data.skillTags ?? []);
         renderTags(document.getElementById('menteeConsultings'), data.consultingTags ?? []);
 
-        setAvatar(data.profileUrl);
+        setAvatar(data.profileUrl, nickname);
 
       } catch (e) {
         err.textContent = '서버와 통신할 수 없습니다.';

--- a/src/main/resources/templates/mypage/mentor/dashboard.html
+++ b/src/main/resources/templates/mypage/mentor/dashboard.html
@@ -14,6 +14,18 @@
         background-position: center;
         background-repeat: no-repeat;
       }
+
+      /* 이니셜 아바타 스타일 */
+      #profileAvatar.avatar-initial {
+        background: linear-gradient(135deg, #667eea 0%, #764ba2 100%) !important;
+        color: white !important;
+        display: flex !important;
+        align-items: center !important;
+        justify-content: center !important;
+        font-weight: 600 !important;
+        font-size: 32px !important;
+        line-height: 1 !important;
+      }
     </style>
   </th:block>
 </head>
@@ -164,15 +176,21 @@
         .replaceAll("'", "&#039;");
     }
 
-    function setAvatar(url) {
+    function setAvatar(url, nickname) {
       const el = document.getElementById('profileAvatar');
       if (!el) return;
 
       if (url) {
+        // 이미지가 있는 경우
         const cacheBusted = url + (url.includes('?') ? '&' : '?') + 't=' + Date.now();
         el.style.backgroundImage = `url(${cacheBusted})`;
+        el.classList.remove('avatar-initial');
+        el.textContent = '';
       } else {
+        // 이미지가 없는 경우 - 이니셜 표시
         el.style.backgroundImage = 'none';
+        el.classList.add('avatar-initial');
+        el.textContent = nickname ? nickname.substring(0, 1).toUpperCase() : 'U';
       }
     }
 
@@ -261,13 +279,14 @@
 
         if (profileRes.ok) {
           const p = profileJson?.data || {};
+          const nickname = p.nickname || '멘토';
           document.getElementById('mentorName').textContent = p.nickname ? `${p.nickname} 멘토` : '멘토';
 
           const job = p.job ?? '-';
           const fields = (p.consultingTags && p.consultingTags.length) ? p.consultingTags.join(', ') : '-';
           document.getElementById('mentorDesc').textContent = `${job} / ${fields}`;
 
-          setAvatar(p.profileUrl);
+          setAvatar(p.profileUrl, nickname);
 
           // 상담 상태 렌더링 + 토글 버튼 연결
           const enabled = !!p.consultationEnabled;

--- a/src/main/resources/templates/mypage/mentor/profile-edit.html
+++ b/src/main/resources/templates/mypage/mentor/profile-edit.html
@@ -24,6 +24,18 @@
       .upload-status {
         font-size: 12px;
       }
+
+      /* 이니셜 아바타 스타일 */
+      #profileAvatar.avatar-initial {
+        background: linear-gradient(135deg, #667eea 0%, #764ba2 100%) !important;
+        color: white !important;
+        display: flex !important;
+        align-items: center !important;
+        justify-content: center !important;
+        font-weight: 600 !important;
+        font-size: 32px !important;
+        line-height: 1 !important;
+      }
     </style>
   </th:block>
 </head>
@@ -156,16 +168,22 @@
         .filter(Boolean);
     }
 
-    function setAvatar(url) {
+    function setAvatar(url, nickname) {
       const avatar = document.getElementById('profileAvatar');
       if (!avatar) return;
 
       if (url) {
+        // 이미지가 있는 경우
         avatar.style.backgroundImage = `url(${url})`;
         avatar.style.backgroundSize = 'cover';
         avatar.style.backgroundPosition = 'center';
+        avatar.classList.remove('avatar-initial');
+        avatar.textContent = '';
       } else {
+        // 이미지가 없는 경우 - 이니셜 표시
         avatar.style.backgroundImage = 'none';
+        avatar.classList.add('avatar-initial');
+        avatar.textContent = nickname ? nickname.substring(0, 1).toUpperCase() : 'U';
       }
     }
 
@@ -200,7 +218,8 @@
         }
 
         const url = json?.data;
-        setAvatar(url);
+        const nickname = document.getElementById('mentorName').textContent.replace(' 멘토', '');
+        setAvatar(url, nickname);
         status.textContent = '업로드 완료';
 
       } catch (err) {
@@ -223,6 +242,7 @@
         }
 
         const data = json?.data || {};
+        const nickname = data.nickname || '멘토';
         document.getElementById('mentorName').textContent = data.nickname ? `${data.nickname} 멘토` : '멘토';
 
         const job = data.job ?? '-';
@@ -234,7 +254,7 @@
           : '-';
         document.getElementById('mentorMeta').textContent = `${job} · ${yearsText} / ${fields}`;
 
-        setAvatar(data.profileUrl);
+        setAvatar(data.profileUrl, nickname);
 
         document.getElementById('jobInput').value = data.job ?? '';
         document.getElementById('careerYearsInput').value = (data.careerYears ?? '');

--- a/src/main/resources/templates/mypage/mentor/profile.html
+++ b/src/main/resources/templates/mypage/mentor/profile.html
@@ -14,6 +14,18 @@
         background-position: center;
         background-repeat: no-repeat;
       }
+
+      /* 이니셜 아바타 스타일 */
+      #profileAvatar.avatar-initial {
+        background: linear-gradient(135deg, #667eea 0%, #764ba2 100%) !important;
+        color: white !important;
+        display: flex !important;
+        align-items: center !important;
+        justify-content: center !important;
+        font-weight: 600 !important;
+        font-size: 32px !important;
+        line-height: 1 !important;
+      }
     </style>
   </th:block>
 </head>
@@ -81,15 +93,21 @@
       root.innerHTML = arr.map(t => `<span class="tag tag--read-only">${escapeHtml(t)}</span>`).join('');
     }
 
-    function setAvatar(url) {
+    function setAvatar(url, nickname) {
       const avatar = document.getElementById('profileAvatar');
       if (!avatar) return;
 
       if (url) {
+        // 이미지가 있는 경우
         const cacheBusted = url + (url.includes('?') ? '&' : '?') + 't=' + Date.now();
         avatar.style.backgroundImage = `url(${cacheBusted})`;
+        avatar.classList.remove('avatar-initial');
+        avatar.textContent = '';
       } else {
+        // 이미지가 없는 경우 - 이니셜 표시
         avatar.style.backgroundImage = 'none';
+        avatar.classList.add('avatar-initial');
+        avatar.textContent = nickname ? nickname.substring(0, 1).toUpperCase() : 'U';
       }
     }
 
@@ -105,6 +123,7 @@
         }
 
         const data = json?.data || {};
+        const nickname = data.nickname || '멘토';
 
         document.getElementById('mentorName').textContent = data.nickname ? `${data.nickname} 멘토` : '멘토';
 
@@ -124,7 +143,7 @@
         renderTags(document.getElementById('mentorSkills'), data.skillTags ?? []);
         renderTags(document.getElementById('mentorConsultings'), data.consultingTags ?? []);
 
-        setAvatar(data.profileUrl);
+        setAvatar(data.profileUrl, nickname);
 
       } catch (e) {
         err.textContent = '서버와 통신할 수 없습니다.';

--- a/src/main/resources/templates/search/fragments/mentor-card.html
+++ b/src/main/resources/templates/search/fragments/mentor-card.html
@@ -1,8 +1,16 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
+
 <div th:fragment="mentorCard(mentor, actionFunction)" class="card-custom mentor-card-custom h-100 d-flex flex-column">
   <div class="mentor-card-header">
-    <img th:src="${mentor.profileUrl != null ? mentor.profileUrl : '/images/default-profile.png'}"
+    <!-- 프로필 이미지가 없으면 닉네임 첫 글자 표시 -->
+    <div th:if="${mentor.profileUrl == null or #strings.isEmpty(mentor.profileUrl)}"
+         class="mentor-card-avatar mentor-card-avatar--initial"
+         th:text="${#strings.substring(mentor.nickname, 0, 1).toUpperCase()}">A
+    </div>
+    <!-- 프로필 이미지가 있으면 이미지 표시 -->
+    <img th:if="${mentor.profileUrl != null and !#strings.isEmpty(mentor.profileUrl)}"
+         th:src="${mentor.profileUrl}"
          th:alt="${mentor.nickname}"
          class="mentor-card-avatar">
     <div style="min-width: 0;">
@@ -55,5 +63,63 @@
             disabled class="btn-outline-custom status-canceled mentor-card-btn" style="cursor: not-allowed;">상담불가
     </button>
   </div>
+</div>
+
+<div th:fragment="recommendCard(mentor)"
+     class="card-custom mentor-card-custom h-100 d-flex flex-column position-relative text-center">
+
+  <div class="match-score-badge">
+    매칭 적합도 <span th:text="${mentor.matchScore}">95</span>점
+  </div>
+
+  <div class="mentor-card-header mt-4 d-flex flex-column align-items-center justify-content-center w-100">
+    <!-- 프로필 이미지가 없으면 닉네임 첫 글자 표시 -->
+    <div th:if="${mentor.profileUrl == null or #strings.isEmpty(mentor.profileUrl)}"
+         class="mentor-card-avatar mentor-card-avatar--initial mb-3"
+         style="margin-right: 0;"
+         th:text="${#strings.substring(mentor.nickname, 0, 1).toUpperCase()}">A
+    </div>
+    <!-- 프로필 이미지가 있으면 이미지 표시 -->
+    <img th:if="${mentor.profileUrl != null and !#strings.isEmpty(mentor.profileUrl)}"
+         th:src="${mentor.profileUrl}"
+         th:alt="${mentor.nickname}"
+         class="mentor-card-avatar mb-3"
+         style="margin-right: 0;">
+
+    <div style="min-width: 0;">
+      <h3 class="mentor-card-title justify-content-center d-flex"
+          th:title="${mentor.nickname}"
+          th:text="${mentor.nickname}">닉네임</h3>
+      <p class="mentor-card-info" th:text="|${mentor.job} · ${mentor.careerYears}년차|">직무 · N년차</p>
+    </div>
+  </div>
+
+  <div class="mentor-tags mb-3 flex-grow-1 justify-content-center w-100">
+        <span th:each="skill, iterStat : ${mentor.skillTags}"
+              th:if="${iterStat.index < 3}"
+              class="tag tag--read-only mentor-tag-small mb-1"
+              th:text="${skill}">Skill</span>
+  </div>
+
+  <div class="mentor-stats d-flex justify-content-center gap-3 mb-3 text-small w-100"
+       style="border-top: none; padding-top: 0.5rem;"> <span class="stat-item" title="추천 리뷰 수">
+            <i class="bi bi-chat-square-text me-1"></i>
+            <span th:text="${mentor.recommendedReviewCount}">0</span>
+        </span>
+    <span class="stat-item" title="진행한 상담">
+            <i class="bi bi-people me-1"></i>
+            <span th:text="${mentor.completedMatchingCount}">0</span>회
+        </span>
+    <span class="stat-item" title="응답률">
+            <i class="bi bi-lightning-charge me-1"></i>
+            <span th:text="${mentor.responseRate}">0</span>%
+        </span>
+  </div>
+
+  <button class="btn-primary-custom mentor-card-btn w-100 mt-auto"
+          th:onclick="requestMatching([[${mentor.mentorId}]], [[${mentor.nickname}]])">
+    이 멘토에게 상담 신청하기
+  </button>
+
 </div>
 </html>


### PR DESCRIPTION
- 프로필 이미지가 없을 때(빈 값/URL 없음) 닉네임 첫 글자(이니셜) 기반 디폴트 아바타 노출로 대체
- 공통 헤더 사용자 아이콘 영역에 동일 정책 적용
- 마이페이지(멘토/멘티) 프로필/프로필 수정/대시보드에 이니셜 아바타 적용
- 검색 멘토카드(mentor-card.html) 프로필 이미지 미존재 시 이니셜 아바타 적용
- 상담방(consultation-room.html) 참여자(멘토/멘티) 프로필 이미지 영역 동일 정책 적용
- 전역 스타일(global.css)로 이니셜 아바타 공통 CSS(원형/정렬/폰트/배경) 정비

## 관련 이슈
- closed: #232

## 작업 내용
- 프로필/헤더/대시보드/멘토카드/상담방에서 프로필 이미지가 없거나 빈 값인 경우, 닉네임 첫 글자 이니셜 아바타가 표시되도록 템플릿과 공통 스타일을 정비했습니다.
- 닉네임이 없거나 예외 케이스에서도 깨지지 않도록 기본 fallback(예: `?`/`U`) 처리 기준에 맞춰 반영했습니다.

## 체크 리스트
- [x] PR 제목 규칙을 준수했습니다
- [x] 관련 이슈를 연결했습니다
- [x] 본문 내용을 명확하게 작성했습니다
- [x] 정상 작동을 로컬 환경에서 검증했습니다

## 리뷰어에게
- 공통 CSS(`global.css`)의 이니셜 아바타 스타일이 기존 프로필 이미지 영역 레이아웃에 영향을 주지 않는지(특히 헤더/멘토카드/상담방) 한 번만 확인 부탁드립니다.

## 연관 이슈
- #232