### PR TITLE
[FEAT] 인기 멘토 조회 api 구현

### DIFF
--- a/src/main/java/org/aibe4/dodeul/domain/member/model/repository/MentorSearchRepository.java
+++ b/src/main/java/org/aibe4/dodeul/domain/member/model/repository/MentorSearchRepository.java
@@ -5,6 +5,10 @@ import org.aibe4.dodeul.domain.search.model.dto.MentorSearchResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+
 public interface MentorSearchRepository {
     Page<MentorSearchResponse> searchMentors(MentorSearchCondition condition, Pageable pageable);
+
+    List<MentorSearchResponse> findPopularMentors();
 }

--- a/src/main/java/org/aibe4/dodeul/domain/search/controller/MentorSearchApiController.java
+++ b/src/main/java/org/aibe4/dodeul/domain/search/controller/MentorSearchApiController.java
@@ -16,6 +16,8 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
 @Tag(name = "Search", description = "멘토 검색 API")
 @RestController
 @RequestMapping("/api/search")
@@ -32,6 +34,14 @@ public class MentorSearchApiController {
         @PageableDefault(size = 10) Pageable pageable) {
 
         Page<MentorSearchResponse> result = mentorSearchService.searchMentors(condition, pageable);
+        return CommonResponse.success(SuccessCode.SUCCESS, result);
+    }
+
+    @Operation(summary = "인기 멘토 조회", description = "추천 수가 가장 많은 10명의 멘토를 조회")
+    @MentorSearchSwaggerDocs.PopularMentors
+    @GetMapping("/mentors/popular")
+    public CommonResponse<List<MentorSearchResponse>> findPopularMentors() {
+        List<MentorSearchResponse> result = mentorSearchService.findPopularMentors();
         return CommonResponse.success(SuccessCode.SUCCESS, result);
     }
 }

--- a/src/main/java/org/aibe4/dodeul/domain/search/controller/MentorSearchSwaggerDocs.java
+++ b/src/main/java/org/aibe4/dodeul/domain/search/controller/MentorSearchSwaggerDocs.java
@@ -64,4 +64,60 @@ public interface MentorSearchSwaggerDocs {
     })
     @interface SearchMentors {
     }
+
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "인기 멘토 조회 성공",
+            content = @Content(
+                schema = @Schema(implementation = CommonResponse.class),
+                examples = @ExampleObject(value = """
+                    {
+                        "code": 200,
+                        "message": "성공",
+                        "data": [
+                            {
+                                "memberId": 10,
+                                "nickname": "스타멘토",
+                                "profileUrl": "https://example.com/profile1.jpg",
+                                "job": "BACKEND",
+                                "careerYears": 7,
+                                "intro": "스타멘토입니다."
+                                "skillTags": ["Spring Boot", "JPA"],
+                                "consultingTags": ["CAREER", "CODEREVIEW"],
+                                "recommendCount": 120,
+                                "completedMatchingCount": 150,
+                                "responseRate": 99.0,
+                                "status": "AVAILABLE"
+                            },
+                            {
+                                "memberId": 5,
+                                "nickname": "AI전문가",
+                                "profileUrl": null,
+                                "job": "AI_ENGINEER",
+                                "careerYears": 5,
+                                "intro": "AI 박사입니다."
+                                "skillTags": ["Python", "TensorFlow"],
+                                "consultingTags": ["CAREER"],
+                                "recommendCount": 98,
+                                "completedMatchingCount": 100,
+                                "responseRate": 95.5,
+                                "status": "FULL"
+                            }
+                        ]
+                    }
+                    """)
+            )),
+        @ApiResponse(responseCode = "500", description = "서버 오류",
+            content = @Content(
+                schema = @Schema(implementation = CommonResponse.class),
+                examples = @ExampleObject(
+                    name = "ServerError",
+                    summary = "서버 내부 오류",
+                    value = "{\"code\": 500, \"message\": \"서버 내부 오류가 발생했습니다.\", \"data\": null}"
+                )
+            ))
+    })
+    @interface PopularMentors {
+    }
 }

--- a/src/main/java/org/aibe4/dodeul/domain/search/model/dto/MentorSearchResponse.java
+++ b/src/main/java/org/aibe4/dodeul/domain/search/model/dto/MentorSearchResponse.java
@@ -36,6 +36,9 @@ public class MentorSearchResponse {
     @Schema(description = "경력(년차)", example = "5")
     private int careerYears;
 
+    @Schema(description = "자기소개", example = "백엔드를 정말 잘합니다.")
+    private String intro;
+
     @Schema(description = "기술 스택 목록", example = "[\"Spring Boot\", \"JPA\", \"Docker\"]")
     private List<String> skillTags;
 
@@ -72,6 +75,7 @@ public class MentorSearchResponse {
             .profileUrl(profile.getProfileUrl())
             .job(profile.getJob())
             .careerYears(profile.getCareerYears())
+            .intro(profile.getIntro())
             .skillTags(member.getSkillTags().stream()
                 .map(mst -> mst.getSkillTag().getName()).toList())
             .consultingTags(member.getConsultingTags().stream()

--- a/src/main/java/org/aibe4/dodeul/domain/search/service/MentorSearchService.java
+++ b/src/main/java/org/aibe4/dodeul/domain/search/service/MentorSearchService.java
@@ -9,6 +9,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -18,5 +20,9 @@ public class MentorSearchService {
 
     public Page<MentorSearchResponse> searchMentors(MentorSearchCondition condition, Pageable pageable) {
         return memberRepository.searchMentors(condition, pageable);
+    }
+
+    public List<MentorSearchResponse> findPopularMentors() {
+        return memberRepository.findPopularMentors();
     }
 }


### PR DESCRIPTION
## 관련 이슈
- closed: #254 

## 작업 내용
- 추천 수가 가장 많은 10명의 멘토를 조회하여 리턴하는 api를 구현한다.

## 체크 리스트
- [x] PR 제목 규칙을 준수했습니다
- [x] 관련 이슈를 연결했습니다
- [x] 본문 내용을 명확하게 작성했습니다
- [x] 정상 작동을 로컬 환경에서 검증했습니다